### PR TITLE
Update and tweak Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 language: rust
 sudo: false
 
-cache:
-  - cargo
+before_install:
+  - target=x86_64-unknown-linux-musl
+  - curl -L https://github.com/mozilla/sccache/releases/download/0.2.7/sccache-0.2.7-$target.tar.gz | tar xzf -
+  - export PATH=$PATH:`pwd`/sccache-0.2.7-$target
+  - export RUSTC_WRAPPER=sccache
+
+after_script:
+  - sccache -s
 
 install:
   - git clone --recursive https://github.com/WebAssembly/wabt.git
   - mkdir wabt/build
   - cd wabt/build
-  - cmake ..
+  - cmake .. -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
   - make -j 8
   - cd -
   - export PATH=$PATH:$(pwd)/wabt/build
@@ -19,13 +25,10 @@ matrix:
   include:
     - name: "test (stable)"
       rust: stable
-      script:
-        - cargo test
     - name: "test (beta)"
       rust: beta
-      script:
-        - cargo test
     - name: "test (nightly)"
       rust: nightly
-      script:
-        - cargo test
+
+script:
+  - cargo test --all

--- a/walrus-tests/tests/round_trip/br_table.wat
+++ b/walrus-tests/tests/round_trip/br_table.wat
@@ -4,7 +4,7 @@
     block
       block
         block
-          get_local 0
+          local.get 0
           br_table 0 1 2
         end
         i32.const 300
@@ -23,7 +23,7 @@
 ;; NEXT:      block  ;; label = @1
 ;; NEXT:        block  ;; label = @2
 ;; NEXT:          block  ;; label = @3
-;; NEXT:            get_local 0
+;; NEXT:            local.get 0
 ;; NEXT:            br_table 0 (;@3;) 1 (;@2;) 2 (;@1;)
 ;; NEXT:          end
 ;; NEXT:          i32.const 300

--- a/walrus-tests/tests/round_trip/call_2.wat
+++ b/walrus-tests/tests/round_trip/call_2.wat
@@ -4,7 +4,7 @@
   (type (;0;) (func (param i32) (result i32)))
   (import "env" "f" (func $f (type 0)))
   (func $g (type 0) (param i32) (result i32)
-    (get_local 0)
+    (local.get 0)
     (call $f))
   (export "g" (func $g)))
 
@@ -13,6 +13,6 @@
 ;; NEXT:    (import "env" "f" (func (;0;) (type 0)))
 ;; NEXT:    (func (;1;) (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32)
-;; NEXT:      get_local 0
+;; NEXT:      local.get 0
 ;; NEXT:      call 0)
 ;; NEXT:    (export "g" (func 1)))

--- a/walrus-tests/tests/round_trip/count-to-ten.wat
+++ b/walrus-tests/tests/round_trip/count-to-ten.wat
@@ -1,10 +1,10 @@
 (module
   (type (;0;) (func (result i32)))
   (func $f (type 0) (local i32)
-    (set_local 0 (i32.const 9))
+    (local.set 0 (i32.const 9))
     loop
-      (br_if 0 (i32.eqz (get_local 0)))
-      (set_local 0 (i32.add (get_local 0) (i32.const 1)))
+      (br_if 0 (i32.eqz (local.get 0)))
+      (local.set 0 (i32.add (local.get 0) (i32.const 1)))
     end
     i32.const 10)
   (export "count_to_ten" (func $f)))
@@ -14,15 +14,15 @@
 ;; NEXT:    (func (;0;) (type 0) (result i32)
 ;; NEXT:      (local i32)
 ;; NEXT:      i32.const 9
-;; NEXT:      set_local 0
+;; NEXT:      local.set 0
 ;; NEXT:      loop  ;; label = @1
-;; NEXT:        get_local 0
+;; NEXT:        local.get 0
 ;; NEXT:        i32.eqz
 ;; NEXT:        br_if 0 (;@1;)
-;; NEXT:        get_local 0
+;; NEXT:        local.get 0
 ;; NEXT:        i32.const 1
 ;; NEXT:        i32.add
-;; NEXT:        set_local 0
+;; NEXT:        local.set 0
 ;; NEXT:      end
 ;; NEXT:      i32.const 10)
 ;; NEXT:    (export "count_to_ten" (func 0)))

--- a/walrus-tests/tests/round_trip/fac.wat
+++ b/walrus-tests/tests/round_trip/fac.wat
@@ -2,30 +2,30 @@
   (type (;0;) (func (param i32) (result i32)))
   (func $fac (type 0) (local i32)
     block
-      get_local 0
-      set_local 1
+      local.get 0
+      local.set 1
       loop
         ;; if local 0 == 0, break
-        get_local 0
+        local.get 0
         i32.eqz
         br_if 1
 
         ;; local 1 = local 0 * local 1
-        get_local 1
-        get_local 0
+        local.get 1
+        local.get 0
         i32.mul
-        set_local 1
+        local.set 1
 
         ;; local 0 = local 0 - 1
-        get_local 0
+        local.get 0
         i32.const 1
         i32.sub
-        set_local 0
+        local.set 0
       end
     end
 
     ;; return the accumulated value
-    get_local 1)
+    local.get 1)
   (export "fac" (func $fac)))
 
 ;; CHECK: (module
@@ -33,21 +33,21 @@
 ;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32 i32)
 ;; NEXT:      block  ;; label = @1
-;; NEXT:        get_local 0
-;; NEXT:        set_local 1
+;; NEXT:        local.get 0
+;; NEXT:        local.set 1
 ;; NEXT:        loop  ;; label = @2
-;; NEXT:          get_local 0
+;; NEXT:          local.get 0
 ;; NEXT:          i32.eqz
 ;; NEXT:          br_if 1 (;@1;)
-;; NEXT:          get_local 1
-;; NEXT:          get_local 0
+;; NEXT:          local.get 1
+;; NEXT:          local.get 0
 ;; NEXT:          i32.mul
-;; NEXT:          set_local 1
-;; NEXT:          get_local 0
+;; NEXT:          local.set 1
+;; NEXT:          local.get 0
 ;; NEXT:          i32.const 1
 ;; NEXT:          i32.sub
-;; NEXT:          set_local 0
+;; NEXT:          local.set 0
 ;; NEXT:        end
 ;; NEXT:      end
-;; NEXT:      get_local 1)
+;; NEXT:      local.get 1)
 ;; NEXT:    (export "fac" (func 0)))

--- a/walrus-tests/tests/round_trip/if_else.wat
+++ b/walrus-tests/tests/round_trip/if_else.wat
@@ -1,7 +1,7 @@
 (module
   (type (;0;) (func (param i32) (result i32)))
   (func $if_else (type 0)
-    get_local 0
+    local.get 0
     if (result i32)
       i32.const 1
     else
@@ -13,7 +13,7 @@
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32)
-;; NEXT:      get_local 0
+;; NEXT:      local.get 0
 ;; NEXT:      if (result i32)  ;; label = @1
 ;; NEXT:        i32.const 1
 ;; NEXT:      else

--- a/walrus-tests/tests/round_trip/if_else_2.wat
+++ b/walrus-tests/tests/round_trip/if_else_2.wat
@@ -3,12 +3,12 @@
 (module
   (type (;0;) (func (param i32) (result i32)))
   (func $if_else (type 0)
-    get_local 0
+    local.get 0
     if (result i32)
-      (set_local 0 (i32.const 2))
+      (local.set 0 (i32.const 2))
       i32.const 1
     else
-      (set_local 0 (i32.const 1))
+      (local.set 0 (i32.const 1))
       i32.const 2
     end)
   (export "if_else" (func $if_else)))
@@ -17,14 +17,14 @@
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32)
-;; NEXT:      get_local 0
+;; NEXT:      local.get 0
 ;; NEXT:      if (result i32)  ;; label = @1
 ;; NEXT:        i32.const 2
-;; NEXT:        set_local 0
+;; NEXT:        local.set 0
 ;; NEXT:        i32.const 1
 ;; NEXT:      else
 ;; NEXT:        i32.const 1
-;; NEXT:        set_local 0
+;; NEXT:        local.set 0
 ;; NEXT:        i32.const 2
 ;; NEXT:      end)
 ;; NEXT:    (export "if_else" (func 0)))

--- a/walrus-tests/tests/round_trip/inc.wat
+++ b/walrus-tests/tests/round_trip/inc.wat
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32) (result i32)))
   (func $inc (type 0) (param i32) (result i32)
     (i32.add
-      (get_local 0)
+      (local.get 0)
       (i32.const 1)))
   (export "inc" (func $inc)))
 
@@ -10,7 +10,7 @@
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32)
-;; NEXT:      get_local 0
+;; NEXT:      local.get 0
 ;; NEXT:      i32.const 1
 ;; NEXT:      i32.add)
 ;; NEXT:    (export "inc" (func 0)))

--- a/walrus-tests/tests/round_trip/select.wat
+++ b/walrus-tests/tests/round_trip/select.wat
@@ -3,7 +3,7 @@
   (func $do_select (type 0) (param i32) (result i32)
     i32.const 2
     i32.const 1
-    get_local 0
+    local.get 0
     select)
   (export "do_select" (func $do_select)))
 
@@ -13,6 +13,6 @@
 ;; NEXT:      (local i32)
 ;; NEXT:      i32.const 1
 ;; NEXT:      i32.const 2
-;; NEXT:      get_local 0
+;; NEXT:      local.get 0
 ;; NEXT:      select)
 ;; NEXT:    (export "do_select" (func 0)))


### PR DESCRIPTION
* Use `sccache` to cache both C++ and Rust compilations
* Drop the `cargo` cache in favor of `sccache`
* Run `cargo test --all` instead of just `cargo test` to ensure all
  tests are run
* Fix tests with the nightly branch of `wabt` where the syntax for
  `get_local` has been changed to `local.get`