### PR TITLE
Clean up some boilerplate during tests

### DIFF
--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -49,8 +49,17 @@ impl Module {
     where
         P: AsRef<Path>,
     {
-        let path = path.as_ref();
-        let module = elements::deserialize_file(path)?;
+        Module::from_buffer(&fs::read(path)?)
+    }
+
+    /// Construct a new module.
+    pub fn from_buffer(mut wasm: &[u8]) -> Result<Module> {
+        use parity_wasm::elements::Deserialize;
+
+        let module = elements::Module::deserialize(&mut wasm)?;
+        if wasm.len() > 0 {
+            failure::bail!("invalid wasm file");
+        }
 
         let data = module.data_section().cloned().unwrap_or_default();
 

--- a/walrus-tests-utils/Cargo.toml
+++ b/walrus-tests-utils/Cargo.toml
@@ -5,3 +5,5 @@ authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+tempfile = "3.0"
+failure = "0.1"

--- a/walrus-tests/Cargo.toml
+++ b/walrus-tests/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2018"
 
 [build-dependencies]
 walkdir = "2.2.5"
-walrus-tests-utils = { path = "../walrus-tests-utils" }
 
 [dev-dependencies]
 failure = "0.1.2"
 parity-wasm = "0.35.7"
 walrus = { path = ".." }
 walrus-tests-utils = { path = "../walrus-tests-utils" }
+
+[lib]
+doctest = false
+test = false

--- a/walrus-tests/tests/ir.rs
+++ b/walrus-tests/tests/ir.rs
@@ -1,25 +1,11 @@
-extern crate failure;
-extern crate parity_wasm;
-extern crate walrus;
-extern crate walrus_tests;
-
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use walrus::dot::Dot;
 
-fn do_assert_ir(wasm_path: &Path, wat_path: &Path) {
-    let module = match walrus::module::Module::from_file(wasm_path) {
-        Ok(m) => m,
-        Err(e) => {
-            eprintln!("got an error:");
-            for c in e.iter_chain() {
-                eprintln!("  {}", c);
-            }
-            eprintln!("{}", e.backtrace());
-            panic!("constructing a new `walrus::Function` failed");
-        }
-    };
+fn run(wat_path: &Path) -> Result<(), failure::Error> {
+    let wasm = walrus_tests_utils::wat2wasm(wat_path);
+    let module = walrus::module::Module::from_buffer(&wasm)?;
 
     let local_funcs: Vec<_> = module
         .functions()
@@ -35,29 +21,19 @@ fn do_assert_ir(wasm_path: &Path, wat_path: &Path) {
     let mut output = String::new();
 
     if env::var("WALRUS_TESTS_DOT").is_ok() {
-        let mut dot_path = PathBuf::from(wasm_path);
-        dot_path.set_extension("dot");
-        let mut dot_file = fs::File::create(dot_path).expect("should create dot file OK");
-        func.dot(&mut dot_file)
-            .expect("should generate dot file OK");
+        let dot_path = wat_path.with_extension("dot");
+        let mut dot_file = fs::File::create(dot_path)?;
+        func.dot(&mut dot_file)?;
     }
 
     output.push_str(&func.to_string());
 
-    let mut out_file = PathBuf::from(wasm_path);
-    out_file.set_extension("out");
-    fs::write(out_file, &output).expect("should write out file OK");
+    let out_file = wat_path.with_extension("out");
+    fs::write(out_file, &output)?;
 
     checker.check(&output);
-}
 
-macro_rules! assert_ir {
-    ($name:ident, $wasm_path:expr, $wat_path:expr) => {
-        #[test]
-        fn $name() {
-            do_assert_ir(Path::new($wasm_path), Path::new($wat_path));
-        }
-    };
+    Ok(())
 }
 
 include!(concat!(env!("OUT_DIR"), "/ir.rs"));

--- a/walrus-tests/tests/round_trip.rs
+++ b/walrus-tests/tests/round_trip.rs
@@ -1,56 +1,28 @@
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use walrus::dot::Dot;
-use walrus_tests_utils::wasm2wat;
+use walrus_tests_utils::{wasm2wat, wat2wasm};
 
-fn do_assert_round_trip(wasm_path: &Path, wat_path: &Path) {
-    let module = match walrus::module::Module::from_file(wasm_path) {
-        Ok(m) => m,
-        Err(e) => {
-            eprintln!("got an error:");
-            for c in e.iter_chain() {
-                eprintln!("  {}", c);
-            }
-            eprintln!("{}", e.backtrace());
-            panic!("constructing a new `walrus::Function` failed");
-        }
-    };
+fn run(wat_path: &Path) -> Result<(), failure::Error> {
+    let wasm = wat2wasm(wat_path);
+    let module = walrus::module::Module::from_buffer(&wasm)?;
 
     if env::var("WALRUS_TESTS_DOT").is_ok() {
         for (i, func) in module.functions().enumerate() {
-            let mut dot_path = PathBuf::from(wasm_path);
-            dot_path.set_extension(format!("{}.dot", i));
-            let mut dot_file = fs::File::create(dot_path).expect("should create dot file OK");
-            func.dot(&mut dot_file)
-                .expect("should generate dot file OK");
+            let dot_path = wat_path.with_extension(&format!("{}.dot", i));
+            let mut dot_file = fs::File::create(dot_path)?;
+            func.dot(&mut dot_file)?;
         }
     }
 
-    let mut out_wasm_file = PathBuf::from(wasm_path);
-    out_wasm_file.set_extension("out.wasm");
-    if let Err(e) = module.emit_wasm_file(&out_wasm_file) {
-        eprintln!("got an error:");
-        for c in e.iter_chain() {
-            eprintln!("  {}", c);
-        }
-        eprintln!("{}", e.backtrace());
-        panic!("writing a `walrus::Module` as wasm failed");
-    }
+    let out_wasm_file = wat_path.with_extension("out.wasm");
+    module.emit_wasm_file(&out_wasm_file)?;
 
-    let out_wat_file = wasm2wat(&out_wasm_file);
-    let checker = walrus_tests::FileCheck::from_file(Path::new(wat_path));
-    let output = fs::read_to_string(out_wat_file).expect("should read wat file OK");
-    checker.check(&output);
-}
-
-macro_rules! assert_round_trip {
-    ($name:ident, $wasm_path:expr, $wat_path:expr) => {
-        #[test]
-        fn $name() {
-            do_assert_round_trip(Path::new($wasm_path), Path::new($wat_path));
-        }
-    };
+    let out_wat = wasm2wat(&out_wasm_file);
+    let checker = walrus_tests::FileCheck::from_file(wat_path);
+    checker.check(&out_wat);
+    Ok(())
 }
 
 include!(concat!(env!("OUT_DIR"), "/round_trip.rs"));


### PR DESCRIPTION
* Defer `wasm2wat` and such until the test itself
* All tests simply execute a `run` function
* Return a `Result` from the `run` function to centralize error handling
* Work with in-memory buffers where possible instead of files