### PR TITLE
Handle all constants with the same IR node

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -145,10 +145,10 @@ pub enum Expr {
         value: ExprId,
     },
 
-    /// `i32.const`
-    I32Const {
+    /// `*.const`
+    Const {
         /// The constant value.
-        value: i32,
+        value: Value,
     },
 
     /// `i32.add`
@@ -262,6 +262,21 @@ pub enum Expr {
     },
 }
 
+/// Constant values that can show up in WebAssembly
+#[derive(Debug, Clone, Copy)]
+pub enum Value {
+    /// A constant 32-bit integer
+    I32(i32),
+    /// A constant 64-bit integer
+    I64(i64),
+    /// A constant 32-bit float
+    F32(f32),
+    /// A constant 64-bit float
+    F64(f64),
+    /// A constant 128-bit vector register
+    V128(u128),
+}
+
 impl Expr {
     /// Are any instructions that follow this expression's instruction (within
     /// the current block) unreachable?
@@ -279,7 +294,7 @@ impl Expr {
             | Expr::Call(..)
             | Expr::LocalGet(..)
             | Expr::LocalSet(..)
-            | Expr::I32Const(..)
+            | Expr::Const(..)
             | Expr::I32Add(..)
             | Expr::I32Sub(..)
             | Expr::I32Mul(..)

--- a/src/module/functions/local_function/display.rs
+++ b/src/module/functions/local_function/display.rs
@@ -152,8 +152,14 @@ impl Visitor for DisplayExpr<'_, '_, '_> {
         self.indented(")")
     }
 
-    fn visit_i32_const(&mut self, expr: &I32Const) -> fmt::Result {
-        self.indented(&format!("(i32.const {})", expr.value))
+    fn visit_const(&mut self, expr: &Const) -> fmt::Result {
+        self.indented(&match expr.value {
+            Value::I32(i) => format!("(i32.const {})", i),
+            Value::I64(i) => format!("(i64.const {})", i),
+            Value::F32(i) => format!("(f32.const {})", i),
+            Value::F64(i) => format!("(f64.const {})", i),
+            Value::V128(i) => format!("(v128.const {})", i),
+        })
     }
 
     fn visit_i32_add(&mut self, expr: &I32Add) -> fmt::Result {

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -184,7 +184,7 @@ impl Visitor for UsedVisitor<'_> {
 
     fn visit_local_get(&mut self, _: &LocalGet) {}
     fn visit_local_set(&mut self, _: &LocalSet) {}
-    fn visit_i32_const(&mut self, _: &I32Const) {}
+    fn visit_const(&mut self, _: &Const) {}
 
     fn visit_memory_size(&mut self, m: &MemorySize) {
         self.used.memories.insert(m.memory);


### PR DESCRIPTION
Expand `I32Const` into just `Const` which stores `enum Value` which has
all the various variants, adding support for other constant instructions
at this time too.