### PR TITLE
Rewrite how visitors work

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,9 +1,7 @@
 //! Utilities for emitting GraphViz dot files.
 
-use std::io::{self, Write};
-
 /// Render something into a GraphViz dot file.
 pub trait Dot {
-    /// Render as dot into the given writer.
-    fn dot(&self, out: &mut Write) -> io::Result<()>;
+    /// Render as dot into the given string.
+    fn dot(&self, out: &mut String);
 }

--- a/src/module/exports.rs
+++ b/src/module/exports.rs
@@ -1,13 +1,13 @@
 //! Exported items in a wasm module.
 
-use crate::module::Module;
-use super::globals::{GlobalId};
-use super::memories::{MemoryId};
-use super::tables::{TableId};
+use super::globals::GlobalId;
+use super::memories::MemoryId;
+use super::tables::TableId;
 use crate::arena_set::ArenaSet;
 use crate::error::{ErrorKind, Result};
 use crate::module::emit::{Emit, IdsToIndices};
 use crate::module::functions::FunctionId;
+use crate::module::Module;
 use crate::passes::Used;
 use failure::Fail;
 use id_arena::Id;
@@ -102,25 +102,29 @@ impl ModuleExports {
 
         for exp in export_section.entries() {
             let item = match *exp.internal() {
-                elements::Internal::Function(f) => module.funcs
+                elements::Internal::Function(f) => module
+                    .funcs
                     .function_for_index(f)
                     .map(ExportItem::Function)
                     .ok_or_else(|| {
                         ErrorKind::InvalidWasm.context("exported function does not exist")
                     })?,
-                elements::Internal::Table(t) => module.tables
+                elements::Internal::Table(t) => module
+                    .tables
                     .table_for_index(t)
                     .map(ExportItem::Table)
                     .ok_or_else(|| {
                         ErrorKind::InvalidWasm.context("exported table does not exist")
                     })?,
-                elements::Internal::Memory(m) => module.memories
+                elements::Internal::Memory(m) => module
+                    .memories
                     .memory_for_index(m)
                     .map(ExportItem::Memory)
                     .ok_or_else(|| {
                         ErrorKind::InvalidWasm.context("exported memory does not exist")
                     })?,
-                elements::Internal::Global(g) => module.globals
+                elements::Internal::Global(g) => module
+                    .globals
                     .global_for_index(g)
                     .map(ExportItem::Global)
                     .ok_or_else(|| {

--- a/src/module/functions/local_function/display.rs
+++ b/src/module/functions/local_function/display.rs
@@ -2,7 +2,7 @@
 
 use crate::ir::*;
 use crate::module::functions::{Function, FunctionKind, ImportedFunction, LocalFunction};
-use std::fmt::{self, Write};
+use std::fmt::Write;
 
 /// A trait for displaying our parsed IR.
 pub trait DisplayIr {
@@ -10,14 +10,13 @@ pub trait DisplayIr {
     type Context;
 
     /// Display this IR into the given formatter.
-    fn display_ir(&self, f: &mut fmt::Formatter, ctx: &Self::Context, indent: usize)
-        -> fmt::Result;
+    fn display_ir(&self, f: &mut String, ctx: &Self::Context, indent: usize);
 }
 
 impl DisplayIr for Function {
     type Context = ();
 
-    fn display_ir(&self, f: &mut fmt::Formatter, _: &(), indent: usize) -> fmt::Result {
+    fn display_ir(&self, f: &mut String, _: &(), indent: usize) {
         assert_eq!(indent, 0);
         match self.kind {
             FunctionKind::Import(ref i) => i.display_ir(f, &(), indent),
@@ -30,19 +29,19 @@ impl DisplayIr for Function {
 impl DisplayIr for ImportedFunction {
     type Context = ();
 
-    fn display_ir(&self, f: &mut fmt::Formatter, _: &(), indent: usize) -> fmt::Result {
+    fn display_ir(&self, f: &mut String, _: &(), indent: usize) {
         assert_eq!(indent, 0);
-        writeln!(f, "(import func)")
+        f.push_str("(import func)");
     }
 }
 
 impl DisplayIr for LocalFunction {
     type Context = ();
 
-    fn display_ir(&self, f: &mut fmt::Formatter, _: &(), indent: usize) -> fmt::Result {
+    fn display_ir(&self, f: &mut String, _: &(), indent: usize) {
         assert_eq!(indent, 0);
 
-        writeln!(f, "(func")?;
+        f.push_str("(func\n");
         let entry = self.entry_block();
 
         let mut visitor = DisplayExpr {
@@ -51,69 +50,71 @@ impl DisplayIr for LocalFunction {
             indent: indent + 1,
             id: entry.into(),
         };
-        self.exprs[entry.into()].visit(&mut visitor)?;
+        self.exprs[entry.into()].visit(&mut visitor);
 
-        writeln!(f, ")")
+        f.push_str(")");
     }
 }
 
-struct DisplayExpr<'a, 'b, 'c> {
+struct DisplayExpr<'a, 'b> {
     func: &'a LocalFunction,
-    f: &'b mut fmt::Formatter<'c>,
+    f: &'b mut String,
     indent: usize,
     id: ExprId,
 }
 
-impl DisplayExpr<'_, '_, '_> {
-    fn indented(&mut self, s: &str) -> fmt::Result {
+impl DisplayExpr<'_, '_> {
+    fn indented(&mut self, s: &str) {
         for _ in 0..self.indent {
-            write!(&mut self.f, "  ")?;
+            self.f.push_str("  ");
         }
-        writeln!(self.f, "{}", s)
+        self.f.push_str(s);
+        self.f.push('\n');
     }
 
-    fn sexp(&mut self, op: &str, operands: &[ExprId]) -> fmt::Result {
+    fn sexp(&mut self, op: &str, operands: &[ExprId]) {
         if operands.is_empty() && !op.contains(";") {
             return self.indented(&format!("({})", op));
         }
 
-        self.indented(&format!("({}", op))?;
+        self.indented(&format!("({}", op));
         self.indent += 1;
         for e in operands {
-            self.visit(*e)?;
+            self.visit(*e);
         }
         self.indent -= 1;
         self.indented(")")
     }
 
-    fn list(&mut self, items: &[ExprId]) -> fmt::Result {
+    fn list(&mut self, items: &[ExprId]) {
         if items.is_empty() {
             return self.indented("()");
         }
-        self.indented("(")?;
+        self.indented("(");
         for i in items {
-            self.visit(*i)?;
+            self.visit(*i);
         }
         self.indented(")")
     }
 
-    fn visit<E>(&mut self, e: E) -> fmt::Result
+    fn visit<E>(&mut self, e: E)
     where
         E: Into<ExprId>,
     {
         let e = e.into();
         let id = self.id;
         self.id = e;
-        self.func.exprs[e].visit(self)?;
+        self.func.exprs[e].visit(self);
         self.id = id;
-        Ok(())
     }
 }
 
-impl Visitor for DisplayExpr<'_, '_, '_> {
-    type Return = fmt::Result;
+impl<'expr> Visitor<'expr> for DisplayExpr<'expr, '_> {
+    fn local_function(&self) -> &'expr LocalFunction {
+        self.func
+    }
 
-    fn visit_block(&mut self, b: &Block) -> fmt::Result {
+    fn visit_block(&mut self, b: &Block) {
         let label = format!(
             "{} ;; e{}",
             match b.kind {
@@ -125,47 +126,47 @@ impl Visitor for DisplayExpr<'_, '_, '_> {
         self.sexp(&label, &b.exprs)
     }
 
-    fn visit_call(&mut self, e: &Call) -> fmt::Result {
+    fn visit_call(&mut self, e: &Call) {
         if e.args.is_empty() {
             return self.indented(&format!("(call {})", e.func.index()));
         }
 
-        self.indented(&format!("(call {}", e.func.index()))?;
+        self.indented(&format!("(call {}", e.func.index()));
         self.indent += 1;
         for a in e.args.iter() {
-            self.visit(*a)?;
+            self.visit(*a);
         }
         self.indent -= 1;
         self.indented(")")
     }
 
-    fn visit_local_get(&mut self, expr: &LocalGet) -> fmt::Result {
+    fn visit_local_get(&mut self, expr: &LocalGet) {
         self.indented(&format!("(local.get {})", expr.local.index()))
     }
 
-    fn visit_local_set(&mut self, expr: &LocalSet) -> fmt::Result {
-        self.indented("(local.set")?;
+    fn visit_local_set(&mut self, expr: &LocalSet) {
+        self.indented("(local.set");
         self.indent += 1;
-        self.indented(&format!("{}", expr.local.index()))?;
-        self.visit(expr.value)?;
+        self.indented(&format!("{}", expr.local.index()));
+        self.visit(expr.value);
         self.indent -= 1;
         self.indented(")")
     }
 
-    fn visit_global_get(&mut self, expr: &GlobalGet) -> fmt::Result {
+    fn visit_global_get(&mut self, expr: &GlobalGet) {
         self.indented(&format!("(global.get {})", expr.global.index()))
     }
 
-    fn visit_global_set(&mut self, expr: &GlobalSet) -> fmt::Result {
-        self.indented("(global.set")?;
+    fn visit_global_set(&mut self, expr: &GlobalSet) {
+        self.indented("(global.set");
         self.indent += 1;
-        self.indented(&format!("{}", expr.global.index()))?;
-        self.visit(expr.value)?;
+        self.indented(&format!("{}", expr.global.index()));
+        self.visit(expr.value);
         self.indent -= 1;
         self.indented(")")
     }
 
-    fn visit_const(&mut self, expr: &Const) -> fmt::Result {
+    fn visit_const(&mut self, expr: &Const) {
         self.indented(&match expr.value {
             Value::I32(i) => format!("(i32.const {})", i),
             Value::I64(i) => format!("(i64.const {})", i),
@@ -175,66 +176,66 @@ impl Visitor for DisplayExpr<'_, '_, '_> {
         })
     }
 
-    fn visit_i32_add(&mut self, expr: &I32Add) -> fmt::Result {
+    fn visit_i32_add(&mut self, expr: &I32Add) {
         self.sexp("i32.add", &[expr.lhs, expr.rhs])
     }
 
-    fn visit_i32_sub(&mut self, expr: &I32Sub) -> fmt::Result {
+    fn visit_i32_sub(&mut self, expr: &I32Sub) {
         self.sexp("i32.sub", &[expr.lhs, expr.rhs])
     }
 
-    fn visit_i32_mul(&mut self, expr: &I32Mul) -> fmt::Result {
+    fn visit_i32_mul(&mut self, expr: &I32Mul) {
         self.sexp("i32.mul", &[expr.lhs, expr.rhs])
     }
 
-    fn visit_i32_eqz(&mut self, e: &I32Eqz) -> fmt::Result {
+    fn visit_i32_eqz(&mut self, e: &I32Eqz) {
         self.sexp("i32.eqz", &[e.expr])
     }
 
-    fn visit_i32_popcnt(&mut self, e: &I32Popcnt) -> fmt::Result {
+    fn visit_i32_popcnt(&mut self, e: &I32Popcnt) {
         self.sexp("i32.popcnt", &[e.expr])
     }
 
-    fn visit_select(&mut self, s: &Select) -> fmt::Result {
+    fn visit_select(&mut self, s: &Select) {
         self.sexp("select", &[s.condition, s.consequent, s.alternative])
     }
 
-    fn visit_unreachable(&mut self, _: &Unreachable) -> fmt::Result {
+    fn visit_unreachable(&mut self, _: &Unreachable) {
         self.indented("unreachable")
     }
 
-    fn visit_br(&mut self, br: &Br) -> fmt::Result {
-        self.indented("(br")?;
+    fn visit_br(&mut self, br: &Br) {
+        self.indented("(br");
         self.indent += 1;
 
         self.indented(&format!("e{} ;; block", {
             let b: ExprId = br.block.into();
             b.index()
-        }))?;
+        }));
 
-        self.list(&br.args)?;
+        self.list(&br.args);
 
         self.indent -= 1;
         self.indented(")")
     }
 
-    fn visit_br_if(&mut self, br: &BrIf) -> fmt::Result {
-        self.indented("(br_if")?;
+    fn visit_br_if(&mut self, br: &BrIf) {
+        self.indented("(br_if");
         self.indent += 1;
 
         self.indented(&format!("e{}", {
             let b: ExprId = br.block.into();
             b.index()
-        }))?;
+        }));
 
-        self.visit(br.condition)?;
-        self.list(&br.args)?;
+        self.visit(br.condition);
+        self.list(&br.args);
 
         self.indent -= 1;
         self.indented(")")
     }
 
-    fn visit_if_else(&mut self, expr: &IfElse) -> fmt::Result {
+    fn visit_if_else(&mut self, expr: &IfElse) {
         self.sexp(
             "if",
             &[
@@ -245,14 +246,14 @@ impl Visitor for DisplayExpr<'_, '_, '_> {
         )
     }
 
-    fn visit_br_table(&mut self, b: &BrTable) -> fmt::Result {
-        self.indented("(br_table")?;
+    fn visit_br_table(&mut self, b: &BrTable) {
+        self.indented("(br_table");
         self.indent += 1;
 
-        self.visit(b.which)?;
+        self.visit(b.which);
 
         let default: ExprId = b.default.into();
-        self.indented(&format!("e{} ;; default", default.index()))?;
+        self.indented(&format!("e{} ;; default", default.index()));
 
         let mut blocks = "[".to_string();
         for (i, bl) in b.blocks.iter().cloned().enumerate() {
@@ -263,23 +264,23 @@ impl Visitor for DisplayExpr<'_, '_, '_> {
             write!(&mut blocks, "e{}", bl.index()).unwrap();
         }
         blocks.push(']');
-        self.indented(&blocks)?;
+        self.indented(&blocks);
 
-        self.list(&b.args)?;
+        self.list(&b.args);
 
         self.indent -= 1;
         self.indented(")")
     }
 
-    fn visit_drop(&mut self, d: &Drop) -> fmt::Result {
+    fn visit_drop(&mut self, d: &Drop) {
         self.sexp("drop", &[d.expr])
     }
 
-    fn visit_return(&mut self, r: &Return) -> fmt::Result {
+    fn visit_return(&mut self, r: &Return) {
         self.sexp("return", &r.values)
     }
 
-    fn visit_memory_size(&mut self, m: &MemorySize) -> fmt::Result {
+    fn visit_memory_size(&mut self, m: &MemorySize) {
         self.indented(&format!("(memory.size {})", m.memory.index()))
     }
 }

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -1,0 +1,276 @@
+use crate::module::functions::LocalFunction;
+use crate::ir::*;
+use crate::module::emit::IdsToIndices;
+use parity_wasm::elements;
+
+pub(crate) fn run(func: &LocalFunction, indices: &IdsToIndices) -> Vec<elements::Instruction> {
+    let mut v = Emit {
+        func,
+        indices,
+        id: func.entry_block().into(),
+        blocks: vec![],
+        instructions: vec![],
+    };
+    v.visit(func.entry_block());
+    v.instructions
+}
+
+struct Emit<'a> {
+    // The function we are visiting.
+    func: &'a LocalFunction,
+
+    // The id of the current expression.
+    id: ExprId,
+
+    // Needed so we can map locals to their indices.
+    indices: &'a IdsToIndices,
+
+    // Stack of blocks that we are currently emitting instructions for. A branch
+    // is only valid if its target is one of these blocks.
+    blocks: Vec<BlockId>,
+
+    // The instruction sequence we are building up to emit.
+    instructions: Vec<elements::Instruction>,
+}
+
+impl Emit<'_> {
+    fn visit<E>(&mut self, e: E)
+    where
+        E: Into<ExprId>,
+    {
+        self.visit_expr_id(e.into())
+    }
+
+    fn visit_expr_id(&mut self, id: ExprId) {
+        use self::Expr::*;
+
+        let old = self.id;
+        self.id = id;
+
+        match &self.func.exprs[id] {
+            Const(e) => self.visit_const(e),
+            Block(e) => self.visit_block(e),
+            BrTable(e) => self.visit_br_table(e),
+            IfElse(e) => self.visit_if_else(e),
+
+            Drop(e) => {
+                self.visit(e.expr);
+                self.emit(elements::Instruction::Drop)
+            }
+
+            Return(e) => {
+                for x in e.values.iter() {
+                    self.visit(*x);
+                }
+                self.emit(elements::Instruction::Return);
+            }
+
+            MemorySize(e) => {
+                let idx = self.indices.get_memory_index(e.memory);
+                // TODO: should upstream a fix to parity-wasm to accept 32-bit
+                // indices for memories.
+                assert!(idx < 256);
+                self.emit(elements::Instruction::CurrentMemory(idx as u8))
+            }
+
+            I32Add(e) => {
+                self.visit(e.lhs);
+                self.visit(e.rhs);
+                self.emit(elements::Instruction::I32Add)
+            }
+
+            I32Sub(e) => {
+                self.visit(e.lhs);
+                self.visit(e.rhs);
+                self.emit(elements::Instruction::I32Sub)
+            }
+
+            I32Mul(e) => {
+                self.visit(e.lhs);
+                self.visit(e.rhs);
+                self.emit(elements::Instruction::I32Mul)
+            }
+
+            I32Eqz(e) => {
+                self.visit(e.expr);
+                self.emit(elements::Instruction::I32Eqz)
+            }
+
+            I32Popcnt(e) => {
+                self.visit(e.expr);
+                self.emit(elements::Instruction::I32Popcnt)
+            }
+
+            Select(e) => {
+                self.visit(e.consequent);
+                self.visit(e.alternative);
+                self.visit(e.condition);
+                self.emit(elements::Instruction::Select)
+            }
+
+            Unreachable(_) => {
+                self.emit(elements::Instruction::Unreachable);
+            }
+
+            Br(e) => {
+                for x in e.args.iter() {
+                    self.visit(*x);
+                }
+                let target = self.branch_target(e.block);
+                self.emit(elements::Instruction::Br(target))
+            }
+
+            BrIf(e) => {
+                for x in e.args.iter() {
+                    self.visit(*x);
+                }
+                self.visit(e.condition);
+                let target = self.branch_target(e.block);
+                self.emit(elements::Instruction::BrIf(target))
+            }
+
+            Call(e) => {
+                for x in e.args.iter() {
+                    self.visit(*x);
+                }
+                let idx = self.indices.get_func_index(e.func);
+                self.emit(elements::Instruction::Call(idx))
+            }
+
+            LocalGet(e) => {
+                let idx = self.indices.get_local_index(e.local);
+                self.emit(elements::Instruction::GetLocal(idx))
+            }
+
+            LocalSet(e) => {
+                self.visit(e.value);
+                let idx = self.indices.get_local_index(e.local);
+                self.emit(elements::Instruction::SetLocal(idx))
+            }
+
+            GlobalGet(e) => {
+                let idx = self.indices.get_global_index(e.global);
+                self.emit(elements::Instruction::GetGlobal(idx))
+            }
+
+            GlobalSet(e) => {
+                self.visit(e.value);
+                let idx = self.indices.get_global_index(e.global);
+                self.emit(elements::Instruction::SetGlobal(idx))
+            }
+        }
+
+        self.id = old;
+    }
+
+    fn emit(&mut self, i: elements::Instruction) {
+        self.instructions.push(i);
+    }
+
+    fn branch_target(&self, block: BlockId) -> u32 {
+        self.blocks
+            .iter()
+            .rev()
+            .skip(1)
+            .position(|b| *b == block)
+            .expect(
+                "attempt to branch to invalid block; bad transformation pass introduced bad branching?",
+            ) as u32
+    }
+
+    fn visit_block(&mut self, e: &Block) {
+        self.blocks.push(Block::new_id(self.id));
+
+        let block_ty = match e.results.len() {
+            0 => elements::BlockType::NoResult,
+            1 => elements::BlockType::Value(e.results[0].into()),
+            _ => panic!(
+                "multiple return values not supported yet; write a transformation to rewrite them"
+            ),
+        };
+
+        match e.kind {
+            BlockKind::Block => self.emit(elements::Instruction::Block(block_ty)),
+            BlockKind::Loop => self.emit(elements::Instruction::Loop(block_ty)),
+            BlockKind::FunctionEntry | BlockKind::IfElse => {}
+        }
+
+        for x in &e.exprs {
+            self.visit(*x);
+        }
+
+        match e.kind {
+            BlockKind::Block | BlockKind::Loop | BlockKind::FunctionEntry => {
+                self.emit(elements::Instruction::End)
+            }
+            BlockKind::IfElse => {}
+        }
+
+        self.blocks.pop();
+    }
+
+    fn visit_const(&mut self, e: &Const) {
+        self.emit(match e.value {
+            Value::I32(i) => elements::Instruction::I32Const(i),
+            Value::I64(i) => elements::Instruction::I64Const(i),
+            Value::F32(i) => elements::Instruction::F32Const(i.to_bits()),
+            Value::F64(i) => elements::Instruction::F64Const(i.to_bits()),
+            Value::V128(i) => elements::Instruction::V128Const(Box::new([
+                (i >> 0) as u8,
+                (i >> 8) as u8,
+                (i >> 16) as u8,
+                (i >> 24) as u8,
+                (i >> 32) as u8,
+                (i >> 40) as u8,
+                (i >> 48) as u8,
+                (i >> 56) as u8,
+                (i >> 64) as u8,
+                (i >> 72) as u8,
+                (i >> 80) as u8,
+                (i >> 88) as u8,
+                (i >> 96) as u8,
+                (i >> 104) as u8,
+                (i >> 112) as u8,
+                (i >> 120) as u8,
+            ])),
+        })
+    }
+
+    fn visit_if_else(&mut self, e: &IfElse) {
+        let block_ty = {
+            let consequent = self.func.block(e.consequent);
+            match consequent.results.len() {
+                0 => elements::BlockType::NoResult,
+                1 => elements::BlockType::Value(consequent.results[0].into()),
+                _ => panic!(
+                    "multiple return values not yet supported; write a transformation to \
+                     rewrite them into single value returns"
+                ),
+            }
+        };
+
+        self.visit(e.condition);
+        self.emit(elements::Instruction::If(block_ty));
+        let _ = self.visit(e.consequent);
+        self.emit(elements::Instruction::Else);
+        let _ = self.visit(e.alternative);
+        self.emit(elements::Instruction::End)
+    }
+
+    fn visit_br_table(&mut self, e: &BrTable) {
+        for x in e.args.iter() {
+            self.visit(*x);
+        }
+        self.visit(e.which);
+        let table = e
+            .blocks
+            .iter()
+            .map(|b| self.branch_target(*b))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let default = self.branch_target(e.default);
+        self.emit(elements::Instruction::BrTable(Box::new(
+            elements::BrTableData { table, default },
+        )))
+    }
+}

--- a/src/module/globals.rs
+++ b/src/module/globals.rs
@@ -1,9 +1,9 @@
 //! Globals within a wasm module.
 
 use crate::error::{ErrorKind, Result};
-use crate::module::Module;
 use crate::module::emit::{Emit, IdsToIndices};
 use crate::module::functions::{Function, LocalFunction};
+use crate::module::Module;
 use crate::passes::Used;
 use crate::ty::{Type, ValType};
 use crate::validation_context::ValidationContext;
@@ -113,13 +113,8 @@ impl ModuleGlobals {
         ));
         let dummy_body =
             elements::FuncBody::new(vec![], elements::Instructions::new(init_expr.to_vec()));
-        let init_expr = LocalFunction::parse(
-            dummy_module,
-            dummy_id,
-            dummy_ty,
-            validation,
-            &dummy_body,
-        )?;
+        let init_expr =
+            LocalFunction::parse(dummy_module, dummy_id, dummy_ty, validation, &dummy_body)?;
         if !init_expr.is_const() {
             return Err(ErrorKind::InvalidWasm
                 .context("global's initialization expression is not constant")

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -104,8 +104,7 @@ impl Module {
         P: AsRef<Path>,
     {
         let buffer = self.emit_wasm()?;
-        fs::write(path, buffer)
-            .context("failed to write wasm module")?;
+        fs::write(path, buffer).context("failed to write wasm module")?;
         Ok(())
     }
 
@@ -147,8 +146,8 @@ impl Module {
             | elements::Section::Reloc(_)
             | elements::Section::Name(_) => 12,
         });
-        let buffer = elements::serialize(module)
-            .context("failed to serialize wasm module to file")?;
+        let buffer =
+            elements::serialize(module).context("failed to serialize wasm module to file")?;
         Ok(buffer)
     }
 }

--- a/walrus-derive/src/lib.rs
+++ b/walrus-derive/src/lib.rs
@@ -30,45 +30,90 @@ pub fn walrus_expr(_attr: TokenStream, input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-fn get_enum_variants(input: &DeriveInput) -> Vec<syn::Variant> {
-    match &input.data {
-        syn::Data::Enum(en) => en.variants.iter().cloned().collect(),
+struct WalrusVariant {
+    syn: syn::Variant,
+    fields: Vec<WalrusFieldOpts>,
+}
+
+#[derive(Default)]
+struct WalrusFieldOpts {
+    skip_visit: bool,
+}
+
+fn get_enum_variants(input: &DeriveInput) -> Vec<WalrusVariant> {
+    let en = match &input.data {
+        syn::Data::Enum(en) => en,
         syn::Data::Struct(_) => {
             panic!("can only put #[walrus_expr] on an enum; found it on a struct")
         }
         syn::Data::Union(_) => {
             panic!("can only put #[walrus_expr] on an enum; found it on a union")
         }
-    }
+    };
+    en.variants
+        .iter()
+        .cloned()
+        .map(|mut variant| {
+            WalrusVariant {
+                fields: variant.fields
+                    .iter_mut()
+                    .map(get_walrus_field_opts)
+                    .collect(),
+                syn: variant,
+            }
+        })
+        .collect()
 }
 
-fn create_types(attrs: &[syn::Attribute], variants: &[syn::Variant]) -> impl quote::ToTokens {
+fn get_walrus_field_opts(variant: &mut syn::Field) -> WalrusFieldOpts {
+    let mut ret = WalrusFieldOpts::default();
+    let ident = syn::Path::from(syn::Ident::new("walrus", Span::call_site()));
+    for i in (0..variant.attrs.len()).rev() {
+        if variant.attrs[i].path != ident {
+            continue
+        }
+        let attr = variant.attrs.remove(i);
+        let group = match attr.tts.into_iter().next().unwrap() {
+            proc_macro2::TokenTree::Group(g) => g,
+            _ => panic!("#[walrus(...)] expected"),
+        };
+        for token in group.stream() {
+            let ident = match token {
+                proc_macro2::TokenTree::Ident(ident) => ident,
+                _ => panic!("unexpected syntax in #[walrus]"),
+            };
+            if ident == "skip_visit" {
+                ret.skip_visit = true;
+            } else {
+                panic!("unexpected walrus attribute: {}", ident)
+            }
+        }
+    }
+    return ret
+}
+
+fn create_types(attrs: &[syn::Attribute], variants: &[WalrusVariant]) -> impl quote::ToTokens {
     let types: Vec<_> = variants
         .iter()
         .map(|v| {
-            let name = &v.ident;
+            let name = &v.syn.ident;
             let id_name = {
                 let mut s = name.to_string();
                 s.push_str("Id");
                 &syn::Ident::new(&s, Span::call_site())
             };
-            let attrs = &v.attrs;
-            let fields: Vec<_> = match v.fields {
-                syn::Fields::Named(ref fs) => fs
-                    .named
-                    .iter()
-                    .map(|f| {
-                        let name = &f.ident;
-                        let attrs = &f.attrs;
-                        let ty = &f.ty;
-                        quote! {
-                            #( #attrs )*
-                            pub #name : #ty,
-                        }
-                    })
-                    .collect(),
-                _ => panic!("#[walrus_expr] expects only named fields in enum variant"),
-            };
+            let attrs = &v.syn.attrs;
+            let fields = v.syn.fields
+                .iter()
+                .map(|f| {
+                    let name = &f.ident;
+                    let attrs = &f.attrs;
+                    let ty = &f.ty;
+                    quote! {
+                        #( #attrs )*
+                        pub #name : #ty,
+                    }
+                });
             quote! {
                 /// An identifier to a `#name` expression.
                 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -113,6 +158,12 @@ fn create_types(attrs: &[syn::Attribute], variants: &[syn::Variant]) -> impl quo
                         #id_name::new(id)
                     }
                 }
+
+                impl<'expr> Visit<'expr> for #id_name {
+                    fn visit<V: Visitor<'expr>>(&self, v: &mut V) {
+                        v.visit_expr_id(&self.0);
+                    }
+                }
             }
         })
         .collect();
@@ -120,7 +171,7 @@ fn create_types(attrs: &[syn::Attribute], variants: &[syn::Variant]) -> impl quo
     let methods: Vec<_> = variants
         .iter()
         .map(|v| {
-            let name = &v.ident;
+            let name = &v.syn.ident;
             let snake_name = name.to_string().to_snake_case();
 
             let is_name = format!("is_{}", snake_name);
@@ -192,8 +243,8 @@ fn create_types(attrs: &[syn::Attribute], variants: &[syn::Variant]) -> impl quo
     let variants: Vec<_> = variants
         .iter()
         .map(|v| {
-            let name = &v.ident;
-            let attrs = &v.attrs;
+            let name = &v.syn.ident;
+            let attrs = &v.syn.attrs;
             quote! {
                 #( #attrs )*
                 #name(#name)
@@ -215,78 +266,171 @@ fn create_types(attrs: &[syn::Attribute], variants: &[syn::Variant]) -> impl quo
     }
 }
 
-fn create_visit(variants: &[syn::Variant]) -> impl quote::ToTokens {
-    let visitor_trait_methods: Vec<_> = variants
-        .iter()
-        .map(|v| {
-            let name = &v.ident;
+fn create_visit(variants: &[WalrusVariant]) -> impl quote::ToTokens {
+    let mut visit_impls = Vec::new();
+    let mut visitor_trait_methods = Vec::new();
+    let mut visit_impl = Vec::new();
 
-            let mut method_name = "visit_".to_string();
-            method_name.push_str(&name.to_string().to_snake_case());
-            let method_name = syn::Ident::new(&method_name, Span::call_site());
-            let doc = format!("Visit `{}`.", name.to_string());
+    for variant in variants {
+        let name = &variant.syn.ident;
+        let name_id = syn::Ident::new(&format!("{}Id", name), Span::call_site());
 
-            quote! {
-                #[doc=#doc]
-                #[inline]
-                fn #method_name(&mut self, expr: &#name ) -> Self::Return;
+        let mut method_name = "visit_".to_string();
+        method_name.push_str(&name.to_string().to_snake_case());
+        let method_name = syn::Ident::new(&method_name, Span::call_site());
+        let method_id_name = syn::Ident::new(&format!("{}_id", method_name), Span::call_site());
+
+        fn extract_name_and_if_list(ty: &syn::Type) -> (&syn::Ident, bool) {
+            let path = match ty {
+                syn::Type::Path(p) => &p.path,
+                _ => panic!("field types must be paths"),
+            };
+            let segment = path.segments.last().unwrap().into_value();
+            let args = match &segment.arguments {
+                syn::PathArguments::None => return (&segment.ident, false),
+                syn::PathArguments::AngleBracketed(a) => &a.args,
+                _ => panic!("invalid path in #[walrus_expr]"),
+            };
+            let mut ty = match args.first().unwrap().into_value() {
+                syn::GenericArgument::Type(ty) => ty,
+                _ => panic!("invalid path in #[walrus_expr]"),
+            };
+            if let syn::Type::Slice(t) = ty {
+                ty = &t.elem;
             }
-        })
-        .collect();
+            match ty {
+                syn::Type::Path(p) => {
+                    let segment = p.path.segments.last().unwrap().into_value();
+                    (&segment.ident, true)
+                }
+                _ => panic!("invalid path in #[walrus_expr]"),
+            }
+        }
 
-    let visit_impl: Vec<_> = variants
-        .iter()
-        .map(|v| {
-            let name = &v.ident;
-            let mut method_name = "visit_".to_string();
-            method_name.push_str(&name.to_string().to_snake_case());
-            let method_name = syn::Ident::new(&method_name, Span::call_site());
-            quote! {
-                Expr::#name( ref e ) => {
-                    visitor.#method_name(e)
+        let visit_fields = variant.syn.fields
+            .iter()
+            .zip(&variant.fields)
+            .enumerate()
+            .filter(|(_, (_, info))| !info.skip_visit)
+            .map(|(i, (field, _info))| {
+                let field_name = match &field.ident {
+                    Some(name) => quote! { #name },
+                    None => quote! { #i },
+                };
+                let (ty_name, list) = extract_name_and_if_list(&field.ty);
+                let mut method_name = "visit_".to_string();
+                method_name.push_str(&ty_name.to_string().to_snake_case());
+                let method_name = syn::Ident::new(&method_name, Span::call_site());
+                if list {
+                    quote! {
+                        for item in self.#field_name.iter() {
+                            visitor.#method_name(item);
+                        }
+                    }
+                } else {
+                    quote! { visitor.#method_name(&self.#field_name); }
+                }
+            });
+
+        visit_impls.push(quote! {
+            impl<'expr> Visit<'expr> for #name {
+                fn visit<V: Visitor<'expr>>(&self, visitor: &mut V) {
+                    #(#visit_fields);*
                 }
             }
-        })
-        .collect();
+        });
+
+        let doc = format!("Visit `{}`.", name.to_string());
+        let doc_id = format!("Visit `{}Id`.", name.to_string());
+        visitor_trait_methods.push(quote! {
+            #[doc=#doc]
+            fn #method_name(&mut self, expr: &#name) {
+                expr.visit(self);
+            }
+
+            #[doc=#doc_id]
+            fn #method_id_name(&mut self, id: &#name_id) {
+                id.visit(self);
+            }
+        });
+
+        let mut method_name = "visit_".to_string();
+        method_name.push_str(&name.to_string().to_snake_case());
+        let method_name = syn::Ident::new(&method_name, Span::call_site());
+        visit_impl.push(quote! {
+            Expr::#name(e) => visitor.#method_name(e),
+        });
+    }
 
     quote! {
         /// A visitor walks over an IR expression tree.
-        pub trait Visitor {
-            /// The return type of the visitor.
-            type Return;
+        pub trait Visitor<'expr>: Sized {
+            /// Return the local function we're visiting
+            fn local_function(&self) -> &'expr crate::module::functions::LocalFunction;
+
+            /// Visit `Expr`.
+            fn visit_expr(&mut self, expr: &'expr Expr) {
+                expr.visit(self)
+            }
+
+            /// Visit `ExprId`.
+            fn visit_expr_id(&mut self, expr: &ExprId) {
+                expr.visit(self);
+            }
+
+            /// Visit `Local`.
+            fn visit_local_id(&mut self, local: &crate::ir::LocalId) {
+                // ...
+            }
+
+            /// Visit `Memory`.
+            fn visit_memory_id(&mut self, memory: &crate::module::memories::MemoryId) {
+                // ...
+            }
+
+            /// Visit `Table`.
+            fn visit_table_id(&mut self, table: &crate::module::tables::TableId) {
+                // ...
+            }
+
+            /// Visit `GlobalId`.
+            fn visit_global_id(&mut self, global: &crate::module::globals::GlobalId) {
+                // ...
+            }
+
+            /// Visit `FunctionId`.
+            fn visit_function_id(&mut self, function: &crate::module::functions::FunctionId) {
+                // ...
+            }
+
+            /// Visit `Value`.
+            fn visit_value(&mut self, value: &crate::ir::Value) {
+                // ...
+            }
 
             #( #visitor_trait_methods )*
         }
 
-        /// Anything that can be visited by a `Visitor`.
-        pub trait Visit {
-            /// Visit this thing with the given visitor.
-            fn visit<V>(&self, visitor: &mut V) -> V::Return
-            where
-                V: Visitor;
-        }
-
-        impl Visit for Expr {
-            fn visit<V>(&self, visitor: &mut V) -> V::Return
-            where
-                V: Visitor
-            {
+        impl<'expr> Visit<'expr> for Expr {
+            fn visit<V>(&self, visitor: &mut V) where V: Visitor<'expr> {
                 match self {
                     #( #visit_impl )*
                 }
             }
         }
+
+        #( #visit_impls )*
     }
 }
 
-fn create_matchers(variants: &[syn::Variant]) -> impl quote::ToTokens {
+fn create_matchers(variants: &[WalrusVariant]) -> impl quote::ToTokens {
     use syn::punctuated::Punctuated;
 
     let matchers: Vec<_> = variants
         .iter()
         .map(|v| {
-            let doc = format!("Match a `{}`", v.ident);
-            let name = syn::Ident::new(&format!("{}Matcher", v.ident), Span::call_site());
+            let doc = format!("Match a `{}`", v.syn.ident);
+            let name = syn::Ident::new(&format!("{}Matcher", v.syn.ident), Span::call_site());
 
             let make_matcher_ty_param = |i| match i {
                 0 => quote! { T },
@@ -312,7 +456,7 @@ fn create_matchers(variants: &[syn::Variant]) -> impl quote::ToTokens {
                 },
             };
 
-            match &v.fields {
+            match &v.syn.fields {
                 syn::Fields::Named(fs) => {
                     for (i, f) in fs
                         .named
@@ -363,7 +507,7 @@ fn create_matchers(variants: &[syn::Variant]) -> impl quote::ToTokens {
             };
 
             let new_doc = format!("Construct a new `{}`", name);
-            let expr = &v.ident;
+            let expr = &v.syn.ident;
             let self_args: Vec<_> = args.iter().map(|a| quote! { self.#a }).collect();
 
             let fields = &fields;

--- a/walrus-tests-utils/src/lib.rs
+++ b/walrus-tests-utils/src/lib.rs
@@ -1,6 +1,6 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::fs;
 use std::sync::{Once, ONCE_INIT};
 
 fn require_wat2wasm() {

--- a/walrus-tests/tests/ir.rs
+++ b/walrus-tests/tests/ir.rs
@@ -21,9 +21,9 @@ fn run(wat_path: &Path) -> Result<(), failure::Error> {
     let mut output = String::new();
 
     if env::var("WALRUS_TESTS_DOT").is_ok() {
-        let dot_path = wat_path.with_extension("dot");
-        let mut dot_file = fs::File::create(dot_path)?;
-        func.dot(&mut dot_file)?;
+        let mut file = String::new();
+        func.dot(&mut file);
+        fs::write(wat_path.with_extension("dot"), file)?;
     }
 
     output.push_str(&func.to_string());

--- a/walrus-tests/tests/round_trip.rs
+++ b/walrus-tests/tests/round_trip.rs
@@ -10,9 +10,9 @@ fn run(wat_path: &Path) -> Result<(), failure::Error> {
 
     if env::var("WALRUS_TESTS_DOT").is_ok() {
         for (i, func) in module.functions().enumerate() {
-            let dot_path = wat_path.with_extension(&format!("{}.dot", i));
-            let mut dot_file = fs::File::create(dot_path)?;
-            func.dot(&mut dot_file)?;
+            let mut file = String::new();
+            func.dot(&mut file);
+            fs::write(wat_path.with_extension(&format!("{}.dot", i)), file)?;
         }
     }
 

--- a/walrus-tests/tests/round_trip/unreachable.wat
+++ b/walrus-tests/tests/round_trip/unreachable.wat
@@ -7,5 +7,6 @@
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
 ;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:      unreachable
 ;; NEXT:      unreachable)
 ;; NEXT:    (export "f" (func 0)))

--- a/walrus-tests/tests/round_trip/unreachable_2.wat
+++ b/walrus-tests/tests/round_trip/unreachable_2.wat
@@ -1,5 +1,3 @@
-;; Instructions after an unreachable should not be emitted.
-
 (module
   (type (;0;) (func (result i32)))
   (func $f (type 0) (result i32)
@@ -10,5 +8,6 @@
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
 ;; NEXT:    (func (;0;) (type 0) (result i32)
-;; NEXT:      unreachable)
+;; NEXT:      unreachable
+;; NEXT:      i32.const 42)
 ;; NEXT:    (export "f" (func 0)))

--- a/walrus-tests/tests/valid.rs
+++ b/walrus-tests/tests/valid.rs
@@ -18,9 +18,9 @@ fn run(wat: &Path) -> Result<(), failure::Error> {
 
     let f = &local_funcs.first().unwrap();
     if env::var("WALRUS_TESTS_DOT").is_ok() {
-        let dot_path = wat.with_extension("dot");
-        let mut dot_file = fs::File::create(dot_path)?;
-        f.dot(&mut dot_file)?;
+        let mut file = String::new();
+        f.dot(&mut file);
+        fs::write(wat.with_extension("dot"), file)?;
     }
 
     Ok(())


### PR DESCRIPTION
This is a large-scale refactoring changing how visitors work. The goal
here is to make writing visitors a bit more concise and future-proof.
The major changes here are:

* The `Visitor` trait now has a default implementation for all methods.
  All methods automatically recurse through the AST, by default
  following `Visit`.

* The `Visitor` no longer has an associated `Return` type.

* The `Visit` trait is implemented for a few more types.

* The `Visitor` trait has "base methods" for all sorts of IDs, including
  `FunctionId` and `TableId`. These base methods do no recurse at all,
  but allow hooking references to these types.

* Many visitors have been simplified and/or cleaned up with this new
  visitor pattern.

* The `EmitVisitor` type has been extracted to its own module as it will
  likely grow quite a lot. This module no longer uses the `Visitor`
  trait but instead uses exhaustive matching to ensure we don't forget
  to write down how to emit something.

One of the caveats I ran into was that there's actually cycles in the
wasm AST, notably from branches to their destination blocks. To handle
these cycles and prevent stack overflows this skips them by default when
visiting. Only a DAG-like structure is visited by default.

Currently this doesn't update the dot or display implementations for
functions, but it's hoped that we can start automatically deriving those
soon!