### PR TITLE
Move the IR display visitor into `#[walrus_expr]`

### DIFF
--- a/src/module/functions/local_function/display.rs
+++ b/src/module/functions/local_function/display.rs
@@ -2,7 +2,8 @@
 
 use crate::ir::*;
 use crate::module::functions::{Function, FunctionKind, ImportedFunction, LocalFunction};
-use std::fmt::Write;
+use id_arena::Id;
+use std::mem;
 
 /// A trait for displaying our parsed IR.
 pub trait DisplayIr {
@@ -41,246 +42,80 @@ impl DisplayIr for LocalFunction {
     fn display_ir(&self, f: &mut String, _: &(), indent: usize) {
         assert_eq!(indent, 0);
 
-        f.push_str("(func\n");
-        let entry = self.entry_block();
-
         let mut visitor = DisplayExpr {
             func: self,
             f,
-            indent: indent + 1,
-            id: entry.into(),
+            indent,
+            first_arg: false,
+            line: 0,
         };
-        self.exprs[entry.into()].visit(&mut visitor);
-
-        f.push_str(")");
+        // leading spaces to leave room for leading expression ids
+        visitor.f.push_str("        (func\n");
+        self.entry_block().visit(&mut visitor);
+        visitor.f.push_str("        )");
     }
 }
 
-struct DisplayExpr<'a, 'b> {
-    func: &'a LocalFunction,
-    f: &'b mut String,
+pub(crate) struct DisplayExpr<'a, 'b> {
+    pub(crate) func: &'a LocalFunction,
+    pub(crate) f: &'b mut String,
     indent: usize,
-    id: ExprId,
+    first_arg: bool,
+    line: usize,
 }
 
 impl DisplayExpr<'_, '_> {
-    fn indented(&mut self, s: &str) {
+    // Prints the index of ids such as memories, locals, globals, etc.
+    pub(crate) fn id<T>(&mut self, id: Id<T>) {
+        self.f.push_str(" ");
+        self.f.push_str(&id.index().to_string());
+    }
+
+    fn line(&mut self) {
+        self.line += 1;
+        self.f.push_str("\n");
+    }
+
+    pub(crate) fn expr_id(&mut self, id: ExprId) {
+
+        // If we're the first argument of a previous expression, then we start
+        // ourselves on a new line. Otherwise we're already starting on a line.
+        let first_arg = mem::replace(&mut self.first_arg, true);
+        if first_arg {
+            self.line();
+        }
+
+        // Start all lines with the id of this expression, used as a handy
+        // debugging reference.
+        self.f.push_str("(;");
+        self.f.push_str(&format!("{:3}", id.index()));
+        self.f.push_str(";)");
+
+        // Start the s-expression of this expression with a properly indented
+        // parentheses. After recursing, which prints everything, we push a new
+        // line if we had any arguments. All instructions end with a newline
+        // afterwards too!
+        self.indent += 1;
+        self.indent();
+        self.f.push_str("(");
+        let start = self.line;
+        id.visit(self);
+        if start != self.line {
+            self.f.push_str("       ");
+            self.indent();
+        }
+        self.indent -= 1;
+        self.f.push_str(")");
+        self.line();
+        self.first_arg = false;
+    }
+
+    fn indent(&mut self) {
+        self.f.push_str(" ");
         for _ in 0..self.indent {
             self.f.push_str("  ");
         }
-        self.f.push_str(s);
-        self.f.push('\n');
-    }
-
-    fn sexp(&mut self, op: &str, operands: &[ExprId]) {
-        if operands.is_empty() && !op.contains(";") {
-            return self.indented(&format!("({})", op));
-        }
-
-        self.indented(&format!("({}", op));
-        self.indent += 1;
-        for e in operands {
-            self.visit(*e);
-        }
-        self.indent -= 1;
-        self.indented(")")
-    }
-
-    fn list(&mut self, items: &[ExprId]) {
-        if items.is_empty() {
-            return self.indented("()");
-        }
-        self.indented("(");
-        for i in items {
-            self.visit(*i);
-        }
-        self.indented(")")
-    }
-
-    fn visit<E>(&mut self, e: E)
-    where
-        E: Into<ExprId>,
-    {
-        let e = e.into();
-        let id = self.id;
-        self.id = e;
-        self.func.exprs[e].visit(self);
-        self.id = id;
     }
 }
 
-impl<'expr> Visitor<'expr> for DisplayExpr<'expr, '_> {
-    fn local_function(&self) -> &'expr LocalFunction {
-        self.func
-    }
-
-    fn visit_block(&mut self, b: &Block) {
-        let label = format!(
-            "{} ;; e{}",
-            match b.kind {
-                BlockKind::IfElse | BlockKind::FunctionEntry | BlockKind::Block => "block",
-                BlockKind::Loop => "loop",
-            },
-            self.id.index(),
-        );
-        self.sexp(&label, &b.exprs)
-    }
-
-    fn visit_call(&mut self, e: &Call) {
-        if e.args.is_empty() {
-            return self.indented(&format!("(call {})", e.func.index()));
-        }
-
-        self.indented(&format!("(call {}", e.func.index()));
-        self.indent += 1;
-        for a in e.args.iter() {
-            self.visit(*a);
-        }
-        self.indent -= 1;
-        self.indented(")")
-    }
-
-    fn visit_local_get(&mut self, expr: &LocalGet) {
-        self.indented(&format!("(local.get {})", expr.local.index()))
-    }
-
-    fn visit_local_set(&mut self, expr: &LocalSet) {
-        self.indented("(local.set");
-        self.indent += 1;
-        self.indented(&format!("{}", expr.local.index()));
-        self.visit(expr.value);
-        self.indent -= 1;
-        self.indented(")")
-    }
-
-    fn visit_global_get(&mut self, expr: &GlobalGet) {
-        self.indented(&format!("(global.get {})", expr.global.index()))
-    }
-
-    fn visit_global_set(&mut self, expr: &GlobalSet) {
-        self.indented("(global.set");
-        self.indent += 1;
-        self.indented(&format!("{}", expr.global.index()));
-        self.visit(expr.value);
-        self.indent -= 1;
-        self.indented(")")
-    }
-
-    fn visit_const(&mut self, expr: &Const) {
-        self.indented(&match expr.value {
-            Value::I32(i) => format!("(i32.const {})", i),
-            Value::I64(i) => format!("(i64.const {})", i),
-            Value::F32(i) => format!("(f32.const {})", i),
-            Value::F64(i) => format!("(f64.const {})", i),
-            Value::V128(i) => format!("(v128.const {})", i),
-        })
-    }
-
-    fn visit_i32_add(&mut self, expr: &I32Add) {
-        self.sexp("i32.add", &[expr.lhs, expr.rhs])
-    }
-
-    fn visit_i32_sub(&mut self, expr: &I32Sub) {
-        self.sexp("i32.sub", &[expr.lhs, expr.rhs])
-    }
-
-    fn visit_i32_mul(&mut self, expr: &I32Mul) {
-        self.sexp("i32.mul", &[expr.lhs, expr.rhs])
-    }
-
-    fn visit_i32_eqz(&mut self, e: &I32Eqz) {
-        self.sexp("i32.eqz", &[e.expr])
-    }
-
-    fn visit_i32_popcnt(&mut self, e: &I32Popcnt) {
-        self.sexp("i32.popcnt", &[e.expr])
-    }
-
-    fn visit_select(&mut self, s: &Select) {
-        self.sexp("select", &[s.condition, s.consequent, s.alternative])
-    }
-
-    fn visit_unreachable(&mut self, _: &Unreachable) {
-        self.indented("unreachable")
-    }
-
-    fn visit_br(&mut self, br: &Br) {
-        self.indented("(br");
-        self.indent += 1;
-
-        self.indented(&format!("e{} ;; block", {
-            let b: ExprId = br.block.into();
-            b.index()
-        }));
-
-        self.list(&br.args);
-
-        self.indent -= 1;
-        self.indented(")")
-    }
-
-    fn visit_br_if(&mut self, br: &BrIf) {
-        self.indented("(br_if");
-        self.indent += 1;
-
-        self.indented(&format!("e{}", {
-            let b: ExprId = br.block.into();
-            b.index()
-        }));
-
-        self.visit(br.condition);
-        self.list(&br.args);
-
-        self.indent -= 1;
-        self.indented(")")
-    }
-
-    fn visit_if_else(&mut self, expr: &IfElse) {
-        self.sexp(
-            "if",
-            &[
-                expr.condition,
-                expr.consequent.into(),
-                expr.alternative.into(),
-            ],
-        )
-    }
-
-    fn visit_br_table(&mut self, b: &BrTable) {
-        self.indented("(br_table");
-        self.indent += 1;
-
-        self.visit(b.which);
-
-        let default: ExprId = b.default.into();
-        self.indented(&format!("e{} ;; default", default.index()));
-
-        let mut blocks = "[".to_string();
-        for (i, bl) in b.blocks.iter().cloned().enumerate() {
-            if i > 0 {
-                blocks.push(' ');
-            }
-            let bl: ExprId = bl.into();
-            write!(&mut blocks, "e{}", bl.index()).unwrap();
-        }
-        blocks.push(']');
-        self.indented(&blocks);
-
-        self.list(&b.args);
-
-        self.indent -= 1;
-        self.indented(")")
-    }
-
-    fn visit_drop(&mut self, d: &Drop) {
-        self.sexp("drop", &[d.expr])
-    }
-
-    fn visit_return(&mut self, r: &Return) {
-        self.sexp("return", &r.values)
-    }
-
-    fn visit_memory_size(&mut self, m: &MemorySize) {
-        self.indented(&format!("(memory.size {})", m.memory.index()))
-    }
-}
+// Note that the main body of `DisplayExpr` is generated by `#[walrus_expr]`

--- a/src/module/functions/mod.rs
+++ b/src/module/functions/mod.rs
@@ -17,6 +17,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 pub use self::local_function::LocalFunction;
+pub(crate) use self::local_function::display::DisplayExpr;
 
 /// A function identifier.
 pub type FunctionId = Id<Function>;

--- a/walrus-tests/src/lib.rs
+++ b/walrus-tests/src/lib.rs
@@ -90,8 +90,11 @@ impl FileCheck {
     }
 }
 
-fn matches(actual: &str, expected: &str) -> bool {
-    println!("{:?}", actual.trim());
-    println!("{:?}", expected.trim());
-    actual.trim().starts_with(expected.trim())
+fn matches(mut actual: &str, expected: &str) -> bool {
+    actual = actual.trim();
+    // skip a leading comment
+    if actual.starts_with("(;") {
+        actual = actual[actual.find(";)").unwrap() + 2..].trim();
+    }
+    actual.starts_with(expected.trim())
 }

--- a/walrus-tests/tests/ir/block.wat
+++ b/walrus-tests/tests/ir/block.wat
@@ -10,15 +10,15 @@
     i32.const 2))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
+;; NEXT:    (block
 ;; NEXT:      (drop
-;; NEXT:        (i32.const 0)
+;; NEXT:        (const 0)
 ;; NEXT:      )
-;; NEXT:      (block ;; e3
+;; NEXT:      (block
 ;; NEXT:        (drop
-;; NEXT:          (i32.const 1)
+;; NEXT:          (const 1)
 ;; NEXT:        )
 ;; NEXT:      )
-;; NEXT:      (i32.const 2)
+;; NEXT:      (const 2)
 ;; NEXT:    )
 ;; NEXT:  )

--- a/walrus-tests/tests/ir/br_table.wat
+++ b/walrus-tests/tests/ir/br_table.wat
@@ -16,26 +16,23 @@
     i32.const 100))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
-;; NEXT:      (block ;; e1
-;; NEXT:        (block ;; e2
-;; NEXT:          (block ;; e3
-;; NEXT:            (br_table
+;; NEXT:    (block
+;; NEXT:      (block
+;; NEXT:        (block
+;; NEXT:          (block
+;; NEXT:            (br.table (;default:e0  [e2 e1];)
 ;; NEXT:              (local.get 0)
-;; NEXT:              e0 ;; default
-;; NEXT:              [e2 e1]
-;; NEXT:              ()
 ;; NEXT:            )
 ;; NEXT:          )
 ;; NEXT:          (return
-;; NEXT:            (i32.const 300)
+;; NEXT:            (const 300)
 ;; NEXT:          )
 ;; NEXT:        )
 ;; NEXT:        (return
-;; NEXT:          (i32.const 200)
+;; NEXT:          (const 200)
 ;; NEXT:        )
 ;; NEXT:      )
-;; NEXT:      (i32.const 100)
+;; NEXT:      (const 100)
 ;; NEXT:    )
 ;; NEXT:  )
 

--- a/walrus-tests/tests/ir/call.wat
+++ b/walrus-tests/tests/ir/call.wat
@@ -6,7 +6,7 @@
   (export "g" (func $g)))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
+;; NEXT:    (block
 ;; NEXT:      (call 0)
 ;; NEXT:    )
 ;; NEXT:  )

--- a/walrus-tests/tests/ir/const.wat
+++ b/walrus-tests/tests/ir/const.wat
@@ -4,8 +4,8 @@
     i32.const 42))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
-;; NEXT:      (i32.const 42)
+;; NEXT:    (block
+;; NEXT:      (const 42)
 ;; NEXT:    )
 ;; NEXT:  )
 

--- a/walrus-tests/tests/ir/count-to-ten.wat
+++ b/walrus-tests/tests/ir/count-to-ten.wat
@@ -11,27 +11,23 @@
   (export "count_to_ten" (func 0)))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
-;; NEXT:      (local.set
-;; NEXT:        0
-;; NEXT:        (i32.const 9)
+;; NEXT:    (block
+;; NEXT:      (local.set 0
+;; NEXT:        (const 9)
 ;; NEXT:      )
-;; NEXT:      (loop ;; e3
-;; NEXT:        (br_if
-;; NEXT:          e0
+;; NEXT:      (loop
+;; NEXT:        (br.if (;e0;)
 ;; NEXT:          (i32.eqz
 ;; NEXT:            (local.get 0)
 ;; NEXT:          )
-;; NEXT:          ()
 ;; NEXT:        )
-;; NEXT:        (local.set
-;; NEXT:          0
+;; NEXT:        (local.set 0
 ;; NEXT:          (i32.add
 ;; NEXT:            (local.get 0)
-;; NEXT:            (i32.const 1)
+;; NEXT:            (const 1)
 ;; NEXT:          )
 ;; NEXT:        )
 ;; NEXT:      )
-;; NEXT:      (i32.const 10)
+;; NEXT:      (const 10)
 ;; NEXT:    )
 ;; NEXT:  )

--- a/walrus-tests/tests/ir/drop.wat
+++ b/walrus-tests/tests/ir/drop.wat
@@ -5,9 +5,9 @@
     drop))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
+;; NEXT:    (block
 ;; NEXT:      (drop
-;; NEXT:        (i32.const 42)
+;; NEXT:        (const 42)
 ;; NEXT:      )
 ;; NEXT:    )
 ;; NEXT:  )

--- a/walrus-tests/tests/ir/fac.wat
+++ b/walrus-tests/tests/ir/fac.wat
@@ -29,32 +29,27 @@
   (export "fac" (func 0)))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
-;; NEXT:      (block ;; e1
-;; NEXT:        (local.set
-;; NEXT:          1
+;; NEXT:    (block
+;; NEXT:      (block
+;; NEXT:        (local.set 1
 ;; NEXT:          (local.get 0)
 ;; NEXT:        )
-;; NEXT:        (loop ;; e4
-;; NEXT:          (br_if
-;; NEXT:            e0
+;; NEXT:        (loop
+;; NEXT:          (br.if (;e0;)
 ;; NEXT:            (i32.eqz
 ;; NEXT:              (local.get 0)
 ;; NEXT:            )
-;; NEXT:            ()
 ;; NEXT:          )
-;; NEXT:          (local.set
-;; NEXT:            1
+;; NEXT:          (local.set 1
 ;; NEXT:            (i32.mul
 ;; NEXT:              (local.get 1)
 ;; NEXT:              (local.get 0)
 ;; NEXT:            )
 ;; NEXT:          )
-;; NEXT:          (local.set
-;; NEXT:            0
+;; NEXT:          (local.set 0
 ;; NEXT:            (i32.sub
 ;; NEXT:              (local.get 0)
-;; NEXT:              (i32.const 1)
+;; NEXT:              (const 1)
 ;; NEXT:            )
 ;; NEXT:          )
 ;; NEXT:        )

--- a/walrus-tests/tests/ir/if_else.wat
+++ b/walrus-tests/tests/ir/if_else.wat
@@ -10,14 +10,14 @@
   (export "if_else" (func 0)))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
+;; NEXT:    (block
 ;; NEXT:      (if
 ;; NEXT:        (local.get 0)
-;; NEXT:        (block ;; e2
-;; NEXT:          (i32.const 1)
+;; NEXT:        (block
+;; NEXT:          (const 1)
 ;; NEXT:        )
-;; NEXT:        (block ;; e4
-;; NEXT:          (i32.const 2)
+;; NEXT:        (block
+;; NEXT:          (const 2)
 ;; NEXT:        )
 ;; NEXT:      )
 ;; NEXT:    )

--- a/walrus-tests/tests/ir/inc.wat
+++ b/walrus-tests/tests/ir/inc.wat
@@ -6,10 +6,10 @@
     i32.add))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
+;; NEXT:    (block
 ;; NEXT:      (i32.add
 ;; NEXT:        (local.get 0)
-;; NEXT:        (i32.const 1)
+;; NEXT:        (const 1)
 ;; NEXT:      )
 ;; NEXT:    )
 ;; NEXT:  )

--- a/walrus-tests/tests/ir/loop.wat
+++ b/walrus-tests/tests/ir/loop.wat
@@ -6,8 +6,8 @@
   (export "inf_loop" (func 0)))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
-;; NEXT:      (loop ;; e1
+;; NEXT:    (block
+;; NEXT:      (loop
 ;; NEXT:      )
 ;; NEXT:    )
 ;; NEXT:  )

--- a/walrus-tests/tests/ir/memory-size.wat
+++ b/walrus-tests/tests/ir/memory-size.wat
@@ -5,7 +5,7 @@
   (export "get" (func 0)))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
+;; NEXT:    (block
 ;; NEXT:      (memory.size 0)
 ;; NEXT:    )
 ;; NEXT:  )

--- a/walrus-tests/tests/ir/select.wat
+++ b/walrus-tests/tests/ir/select.wat
@@ -7,11 +7,11 @@
     select))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
+;; NEXT:    (block
 ;; NEXT:      (select
 ;; NEXT:        (local.get 0)
-;; NEXT:        (i32.const 1)
-;; NEXT:        (i32.const 2)
+;; NEXT:        (const 1)
+;; NEXT:        (const 2)
 ;; NEXT:      )
 ;; NEXT:    )
 ;; NEXT:  )

--- a/walrus-tests/tests/ir/stuff-after-loop-2.wat
+++ b/walrus-tests/tests/ir/stuff-after-loop-2.wat
@@ -7,13 +7,10 @@
     i32.const 1))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
-;; NEXT:      (loop ;; e1
-;; NEXT:        (br
-;; NEXT:          e0 ;; block
-;; NEXT:          ()
-;; NEXT:        )
+;; NEXT:    (block
+;; NEXT:      (loop
+;; NEXT:        (br (;e0;))
 ;; NEXT:      )
-;; NEXT:      (i32.const 1)
+;; NEXT:      (const 1)
 ;; NEXT:    )
 ;; NEXT:  )

--- a/walrus-tests/tests/ir/stuff-after-loop.wat
+++ b/walrus-tests/tests/ir/stuff-after-loop.wat
@@ -6,9 +6,8 @@
     i32.const 1))
 
 ;; CHECK: (func
-;; NEXT:    (block ;; e0
-;; NEXT:      (loop ;; e1
-;; NEXT:      )
-;; NEXT:      (i32.const 1)
+;; NEXT:    (block
+;; NEXT:      (loop)
+;; NEXT:      (const 1)
 ;; NEXT:    )
 ;; NEXT:  )


### PR DESCRIPTION
This should reduce the overhead when adding instructions and also ensure
that all instructions are numbered and such. A sample of the new
debugging output is:

            (func
    (;  0;)   (block
    (;  2;)     (local.set 0
    (;  1;)       (const 9)
                )
    (;  3;)     (loop
    (;  6;)       (br.if (;e0;)
    (;  5;)         (i32.eqz
    (;  4;)           (local.get 0)
                    )
                  )
    (; 10;)       (local.set 0
    (;  9;)         (i32.add
    (;  7;)           (local.get 0)
    (;  8;)           (const 1)
                    )
                  )
                )
    (; 11;)     (const 10)
              )
            )

The tests have been updated for the new output as well. Note that the
expression ids aren't included in the test output but are instead
stripped out, as it's not too critical to be matching them.