### PR TITLE
Derive `DotVisitor` as part of `#[walrus_expr]` 

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -8,12 +8,12 @@ pub mod matcher;
 
 use crate::dot::Dot;
 use crate::module::functions::FunctionId;
-use crate::module::memories::MemoryId;
-use crate::module::globals::GlobalId;
 use crate::module::functions::{DisplayExpr, DotExpr};
+use crate::module::globals::GlobalId;
+use crate::module::memories::MemoryId;
 use crate::ty::ValType;
-use std::fmt;
 use id_arena::Id;
+use std::fmt;
 use walrus_derive::walrus_expr;
 
 /// The id of a local.
@@ -399,18 +399,25 @@ fn dot_block_name(block: &Block, out: &mut DotExpr<'_, '_>) {
 }
 
 fn display_br(e: &Br, out: &mut DisplayExpr) {
-    out.f.push_str(&format!(" (;e{};)", ExprId::from(e.block).index()))
+    out.f
+        .push_str(&format!(" (;e{};)", ExprId::from(e.block).index()))
 }
 
 fn display_br_if(e: &BrIf, out: &mut DisplayExpr) {
-    out.f.push_str(&format!(" (;e{};)", ExprId::from(e.block).index()))
+    out.f
+        .push_str(&format!(" (;e{};)", ExprId::from(e.block).index()))
 }
 
 fn display_br_table(e: &BrTable, out: &mut DisplayExpr) {
-    let blocks = e.blocks
+    let blocks = e
+        .blocks
         .iter()
         .map(|b| format!("e{}", ExprId::from(*b).index()))
         .collect::<Vec<_>>()
         .join(" ");
-    out.f.push_str(&format!(" (;default:e{}  [{}];)", ExprId::from(e.default).index(), blocks))
+    out.f.push_str(&format!(
+        " (;default:e{}  [{}];)",
+        ExprId::from(e.default).index(),
+        blocks
+    ))
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -10,7 +10,7 @@ use crate::dot::Dot;
 use crate::module::functions::FunctionId;
 use crate::module::memories::MemoryId;
 use crate::module::globals::GlobalId;
-use crate::module::functions::DisplayExpr;
+use crate::module::functions::{DisplayExpr, DotExpr};
 use crate::ty::ValType;
 use std::fmt;
 use id_arena::Id;
@@ -108,7 +108,7 @@ pub enum BlockKind {
 #[derive(Clone, Debug)]
 pub enum Expr {
     /// A block of multiple expressions, and also a control frame.
-    #[walrus(display_name = display_block_name)]
+    #[walrus(display_name = display_block_name, dot_name = dot_block_name)]
     Block {
         /// What kind of block is this?
         #[walrus(skip_visit)] // nothing to recurse
@@ -386,6 +386,15 @@ fn display_block_name(block: &Block, out: &mut DisplayExpr) {
     match block.kind {
         BlockKind::Loop => out.f.push_str("loop"),
         _ => out.f.push_str("block"),
+    }
+}
+
+fn dot_block_name(block: &Block, out: &mut DotExpr<'_, '_>) {
+    match block.kind {
+        BlockKind::Loop => out.out.push_str("loop"),
+        BlockKind::IfElse => out.out.push_str("if_else"),
+        BlockKind::FunctionEntry => out.out.push_str("entry"),
+        BlockKind::Block => out.out.push_str("block"),
     }
 }
 

--- a/src/module/functions/local_function/display.rs
+++ b/src/module/functions/local_function/display.rs
@@ -77,7 +77,6 @@ impl DisplayExpr<'_, '_> {
     }
 
     pub(crate) fn expr_id(&mut self, id: ExprId) {
-
         // If we're the first argument of a previous expression, then we start
         // ourselves on a new line. Otherwise we're already starting on a line.
         let first_arg = mem::replace(&mut self.first_arg, true);

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -1,6 +1,6 @@
-use crate::module::functions::LocalFunction;
 use crate::ir::*;
 use crate::module::emit::IdsToIndices;
+use crate::module::functions::LocalFunction;
 use parity_wasm::elements;
 
 pub(crate) fn run(func: &LocalFunction, indices: &IdsToIndices) -> Vec<elements::Instruction> {
@@ -174,8 +174,8 @@ impl Emit<'_> {
             .skip(1)
             .position(|b| *b == block)
             .expect(
-                "attempt to branch to invalid block; bad transformation pass introduced bad branching?",
-            ) as u32
+            "attempt to branch to invalid block; bad transformation pass introduced bad branching?",
+        ) as u32
     }
 
     fn visit_block(&mut self, e: &Block) {

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -1,10 +1,9 @@
 //! Functions defined locally within a wasm module.
 
 mod context;
-mod emit;
 pub mod display;
+mod emit;
 
-use std::mem;
 use self::context::FunctionContext;
 use super::FunctionId;
 use crate::dot::Dot;
@@ -15,12 +14,13 @@ use crate::module::emit::IdsToIndices;
 use crate::module::Module;
 use crate::ty::{TypeId, ValType};
 use crate::validation_context::ValidationContext;
-use failure::{Fail, ResultExt, format_err, bail};
+use failure::{bail, format_err, Fail, ResultExt};
 use id_arena::{Arena, Id};
 use parity_wasm::elements::{self, Instruction};
 use std::collections::{BTreeSet, HashSet};
 use std::fmt;
 use std::iter;
+use std::mem;
 
 /// A function defined locally within the wasm module.
 #[derive(Debug)]
@@ -343,7 +343,7 @@ impl DotExpr<'_, '_> {
         let prev = mem::replace(&mut self.id, id);
         id.dot(self.out);
         self.out.push_str(
-            " [label=<<table cellborder=\"0\" border=\"0\"><tr><td><font face=\"monospace\">"
+            " [label=<<table cellborder=\"0\" border=\"0\"><tr><td><font face=\"monospace\">",
         );
         self.needs_close = true;
         id.visit(self);
@@ -493,14 +493,20 @@ fn validate_instruction<'a>(
             ctx.add_to_current_frame_block(expr);
         }
         Instruction::GetGlobal(n) => {
-            let global = ctx.module.globals.global_for_index(*n)
+            let global = ctx
+                .module
+                .globals
+                .global_for_index(*n)
                 .ok_or_else(|| format_err!("invalid global.get index"))?;
             let ty = ctx.module.globals.arena[global].ty;
             let expr = ctx.func.alloc(GlobalGet { global });
             ctx.push_operand(Some(ty), expr);
         }
         Instruction::SetGlobal(n) => {
-            let global = ctx.module.globals.global_for_index(*n)
+            let global = ctx
+                .module
+                .globals
+                .global_for_index(*n)
                 .ok_or_else(|| format_err!("invalid global.get index"))?;
             let ty = ctx.module.globals.arena[global].ty;
             let (_, value) = ctx.pop_operand_expected(Some(ty))?;

--- a/src/module/functions/mod.rs
+++ b/src/module/functions/mod.rs
@@ -17,7 +17,10 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 pub use self::local_function::LocalFunction;
+
+// have generated impls from the `#[walrus_expr]` macro
 pub(crate) use self::local_function::display::DisplayExpr;
+pub(crate) use self::local_function::DotExpr;
 
 /// A function identifier.
 pub type FunctionId = Id<Function>;

--- a/src/validation_context.rs
+++ b/src/validation_context.rs
@@ -5,8 +5,8 @@ use super::error::{ErrorKind, Result};
 use crate::ty::{Type, ValType};
 use failure::{Fail, ResultExt};
 use parity_wasm::elements;
-use std::u16;
 use std::iter;
+use std::u16;
 use std::u32;
 
 /// Wasm validation context.

--- a/walrus-derive/src/lib.rs
+++ b/walrus-derive/src/lib.rs
@@ -7,12 +7,12 @@ use heck::SnakeCase;
 use proc_macro2::Span;
 use quote::quote;
 use std::iter::FromIterator;
-use syn::DeriveInput;
 use syn::ext::IdentExt;
-use syn::Error;
-use syn::{parse_macro_input, Ident, Result, Token};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
+use syn::DeriveInput;
+use syn::Error;
+use syn::{parse_macro_input, Ident, Result, Token};
 
 #[proc_macro_attribute]
 pub fn walrus_expr(_attr: TokenStream, input: TokenStream) -> TokenStream {
@@ -77,11 +77,10 @@ fn get_enum_variants(input: &DeriveInput) -> Result<Vec<WalrusVariant>> {
             let attrs = walrus_attrs(&mut variant.attrs);
 
             Ok(WalrusVariant {
-                fields: variant.fields
+                fields: variant
+                    .fields
                     .iter_mut()
-                    .map(|field| {
-                        syn::parse(walrus_attrs(&mut field.attrs))
-                    })
+                    .map(|field| syn::parse(walrus_attrs(&mut field.attrs)))
                     .collect::<Result<_>>()?,
                 syn: variant,
                 opts: syn::parse(attrs)?,
@@ -107,11 +106,11 @@ impl Parse for WalrusFieldOpts {
 
         impl Parse for Attr {
             fn parse(input: ParseStream) -> Result<Self> {
-				let attr: Ident = input.parse()?;
-				if attr == "skip_visit" {
-					return Ok(Attr::SkipVisit)
-				}
-				return Err(Error::new(attr.span(), "unexpected attribute"));
+                let attr: Ident = input.parse()?;
+                if attr == "skip_visit" {
+                    return Ok(Attr::SkipVisit);
+                }
+                return Err(Error::new(attr.span(), "unexpected attribute"));
             }
         }
     }
@@ -138,23 +137,23 @@ impl Parse for WalrusVariantOpts {
 
         impl Parse for Attr {
             fn parse(input: ParseStream) -> Result<Self> {
-				let attr: Ident = input.parse()?;
-				if attr == "display_name" {
+                let attr: Ident = input.parse()?;
+                if attr == "display_name" {
                     input.parse::<Token![=]>()?;
                     let name = input.call(Ident::parse_any)?;
-					return Ok(Attr::DisplayName(name))
-				}
-				if attr == "display_extra" {
+                    return Ok(Attr::DisplayName(name));
+                }
+                if attr == "display_extra" {
                     input.parse::<Token![=]>()?;
                     let name = input.call(Ident::parse_any)?;
-					return Ok(Attr::DisplayExtra(name))
-				}
-				if attr == "dot_name" {
+                    return Ok(Attr::DisplayExtra(name));
+                }
+                if attr == "dot_name" {
                     input.parse::<Token![=]>()?;
                     let name = input.call(Ident::parse_any)?;
-					return Ok(Attr::DotName(name))
-				}
-				return Err(Error::new(attr.span(), "unexpected attribute"));
+                    return Ok(Attr::DotName(name));
+                }
+                return Err(Error::new(attr.span(), "unexpected attribute"));
             }
         }
     }
@@ -165,7 +164,7 @@ fn walrus_attrs(attrs: &mut Vec<syn::Attribute>) -> TokenStream {
     let ident = syn::Path::from(syn::Ident::new("walrus", Span::call_site()));
     for i in (0..attrs.len()).rev() {
         if attrs[i].path != ident {
-            continue
+            continue;
         }
         let attr = attrs.remove(i);
         let group = match attr.tts.into_iter().next().unwrap() {
@@ -173,9 +172,9 @@ fn walrus_attrs(attrs: &mut Vec<syn::Attribute>) -> TokenStream {
             _ => panic!("#[walrus(...)] expected"),
         };
         ret.extend(group.stream());
-        ret.extend(quote!{ , });
+        ret.extend(quote! { , });
     }
-    return ret.into()
+    return ret.into();
 }
 
 fn create_types(attrs: &[syn::Attribute], variants: &[WalrusVariant]) -> impl quote::ToTokens {
@@ -189,17 +188,15 @@ fn create_types(attrs: &[syn::Attribute], variants: &[WalrusVariant]) -> impl qu
                 &syn::Ident::new(&s, Span::call_site())
             };
             let attrs = &v.syn.attrs;
-            let fields = v.syn.fields
-                .iter()
-                .map(|f| {
-                    let name = &f.ident;
-                    let attrs = &f.attrs;
-                    let ty = &f.ty;
-                    quote! {
-                        #( #attrs )*
-                        pub #name : #ty,
-                    }
-                });
+            let fields = v.syn.fields.iter().map(|f| {
+                let name = &f.ident;
+                let attrs = &f.attrs;
+                let ty = &f.ty;
+                quote! {
+                    #( #attrs )*
+                    pub #name : #ty,
+                }
+            });
             quote! {
                 /// An identifier to a `#name` expression.
                 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -352,10 +349,13 @@ fn create_types(attrs: &[syn::Attribute], variants: &[WalrusVariant]) -> impl qu
     }
 }
 
-fn visit_fields<'a>(variant: &'a WalrusVariant, allow_skip: bool)
-    -> impl Iterator<Item = (syn::Ident, proc_macro2::TokenStream, bool)> + 'a
-{
-    return variant.syn.fields
+fn visit_fields<'a>(
+    variant: &'a WalrusVariant,
+    allow_skip: bool,
+) -> impl Iterator<Item = (syn::Ident, proc_macro2::TokenStream, bool)> + 'a {
+    return variant
+        .syn
+        .fields
         .iter()
         .zip(&variant.fields)
         .enumerate()
@@ -414,18 +414,17 @@ fn create_visit(variants: &[WalrusVariant]) -> impl quote::ToTokens {
         let method_name = syn::Ident::new(&method_name, Span::call_site());
         let method_id_name = syn::Ident::new(&format!("{}_id", method_name), Span::call_site());
 
-        let visit_fields = visit_fields(variant, true)
-            .map(|(method_name, field_name, list)| {
-                if list {
-                    quote! {
-                        for item in self.#field_name.iter() {
-                            visitor.#method_name(item);
-                        }
+        let visit_fields = visit_fields(variant, true).map(|(method_name, field_name, list)| {
+            if list {
+                quote! {
+                    for item in self.#field_name.iter() {
+                        visitor.#method_name(item);
                     }
-                } else {
-                    quote! { visitor.#method_name(&self.#field_name); }
                 }
-            });
+            } else {
+                quote! { visitor.#method_name(&self.#field_name); }
+            }
+        });
 
         visit_impls.push(quote! {
             impl<'expr> Visit<'expr> for #name {
@@ -738,9 +737,7 @@ fn create_dot(variants: &[WalrusVariant]) -> impl quote::ToTokens {
             }
         };
         let field_edges = visit_fields(variant, false)
-            .filter(|(method, _, _)| {
-                method == "visit_expr_id" || method == "visit_block_id"
-            })
+            .filter(|(method, _, _)| method == "visit_expr_id" || method == "visit_block_id")
             .map(|(_ty, accessor, list)| {
                 if list {
                     quote! {

--- a/walrus-tests/src/lib.rs
+++ b/walrus-tests/src/lib.rs
@@ -30,21 +30,20 @@ impl FileCheck {
     }
 
     pub fn check(&self, output: &str) {
-        let output_lines = output
-            .lines()
-            .collect::<Vec<_>>();
+        let output_lines = output.lines().collect::<Vec<_>>();
 
-        'outer:
-        for pattern in &self.patterns {
+        'outer: for pattern in &self.patterns {
             let first_line = &pattern[0];
 
             let mut start = 0;
 
-            'inner:
-            while let Some(pos) = output_lines[start..].iter().position(|l| matches(*l, first_line)) {
+            'inner: while let Some(pos) = output_lines[start..]
+                .iter()
+                .position(|l| matches(*l, first_line))
+            {
                 start = pos + 1;
                 if output_lines[pos..].len() + 1 < pattern.len() {
-                    break
+                    break;
                 }
                 for (out_line, pat_line) in output_lines[pos + 1..].iter().zip(&pattern[1..]) {
                     if !matches(out_line, pat_line) {
@@ -62,13 +61,7 @@ impl FileCheck {
         let pattern = pattern
             .iter()
             .enumerate()
-            .map(|(i, l)| {
-                format!(
-                    "    {}: {}",
-                    if i == 0 { "CHECK" } else { "NEXT" },
-                    l,
-                )
-            })
+            .map(|(i, l)| format!("    {}: {}", if i == 0 { "CHECK" } else { "NEXT" }, l,))
             .collect::<Vec<_>>()
             .join("\n");
 


### PR DESCRIPTION
This commit updates the internal graphviz emission to be auto-generated
as a result of the structural components of `enum Expr`. This is again
aimed at making it easier to add new instructions, ensuring that a
hopefully bare minimum of code needs to be added to support each new
instruction, reducing the amount of boilerplate.