### PR TITLE
Remove `ty` from `LocalGet` and `LocalSet`

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -135,18 +135,12 @@ pub enum Expr {
 
     /// `local.get n`
     LocalGet {
-        /// The type of this local.
-        #[walrus(skip_visit)] // nothing to recurse
-        ty: ValType,
         /// The local being got.
         local: LocalId,
     },
 
     /// `local.set n`
     LocalSet {
-        /// The type of this local.
-        #[walrus(skip_visit)] // nothing to recurse
-        ty: ValType,
         /// The local being set.
         local: LocalId,
         /// The value to set the local to.

--- a/src/module/emit.rs
+++ b/src/module/emit.rs
@@ -16,10 +16,19 @@ use std::collections::HashMap;
 
 /// Anything that can be lowered to raw wasm structures.
 pub(crate) trait Emit {
+    /// Extra data, if any, passed into `emit`.
+    type Extra;
+
     /// Emit `self` into the given module.
     ///
     /// Anything that is not in the `used` set should not be emitted.
-    fn emit(&self, used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices);
+    fn emit(
+        &self,
+        extra: &Self::Extra,
+        used: &Used,
+        module: &mut elements::Module,
+        indices: &mut IdsToIndices,
+    );
 }
 
 /// Maps our high-level identifiers to the raw indices they end up emitted at.

--- a/src/module/exports.rs
+++ b/src/module/exports.rs
@@ -142,7 +142,15 @@ impl ModuleExports {
 }
 
 impl Emit for ModuleExports {
-    fn emit(&self, _used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
+    type Extra = ();
+
+    fn emit(
+        &self,
+        _: &(),
+        _used: &Used,
+        module: &mut elements::Module,
+        indices: &mut IdsToIndices,
+    ) {
         // NB: exports are always considered used. They are the roots that the
         // used analysis searches out from.
 

--- a/src/module/functions/mod.rs
+++ b/src/module/functions/mod.rs
@@ -6,6 +6,7 @@ use crate::dot::Dot;
 use crate::error::{ErrorKind, Result};
 use crate::module::emit::{Emit, IdsToIndices};
 use crate::module::imports::{ImportId, ImportKind};
+use crate::module::locals::ModuleLocals;
 use crate::module::Module;
 use crate::passes::Used;
 use crate::ty::TypeId;
@@ -256,7 +257,15 @@ impl Module {
 }
 
 impl Emit for ModuleFunctions {
-    fn emit(&self, used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
+    type Extra = ModuleLocals;
+
+    fn emit(
+        &self,
+        locals: &ModuleLocals,
+        used: &Used,
+        module: &mut elements::Module,
+        indices: &mut IdsToIndices,
+    ) {
         if used.funcs.is_empty() {
             return;
         }
@@ -321,7 +330,7 @@ impl Emit for ModuleFunctions {
             let ty_idx = indices.get_type_index(func.ty);
             funcs.push(elements::Func::new(ty_idx));
 
-            let locals = func.emit_locals(indices);
+            let locals = func.emit_locals(locals, indices);
             let instructions = func.emit_instructions(indices);
             let instructions = elements::Instructions::new(instructions);
             codes.push(elements::FuncBody::new(locals, instructions));

--- a/src/module/globals.rs
+++ b/src/module/globals.rs
@@ -134,7 +134,9 @@ impl ModuleGlobals {
 }
 
 impl Emit for ModuleGlobals {
-    fn emit(&self, used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
+    type Extra = ();
+
+    fn emit(&self, _: &(), used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
         if used.globals.is_empty() {
             return;
         }

--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -230,7 +230,9 @@ impl ModuleImports {
 }
 
 impl Emit for ModuleImports {
-    fn emit(&self, used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
+    type Extra = ();
+
+    fn emit(&self, _: &(), used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
         if used.imports.is_empty() {
             return;
         }

--- a/src/module/locals.rs
+++ b/src/module/locals.rs
@@ -49,12 +49,12 @@ impl ModuleLocals {
     }
 
     /// Get the set of locals for this module.
-    pub fn locals(&self) -> &Arena<Local> {
+    pub(crate) fn locals(&self) -> &Arena<Local> {
         &self.locals
     }
 
     /// Get the set of locals for this module.
-    pub fn locals_mut(&mut self) -> &mut Arena<Local> {
+    pub(crate) fn locals_mut(&mut self) -> &mut Arena<Local> {
         &mut self.locals
     }
 }

--- a/src/module/locals.rs
+++ b/src/module/locals.rs
@@ -47,4 +47,14 @@ impl ModuleLocals {
         debug_assert_eq!(id, id2);
         id
     }
+
+    /// Get the set of locals for this module.
+    pub fn locals(&self) -> &Arena<Local> {
+        &self.locals
+    }
+
+    /// Get the set of locals for this module.
+    pub fn locals_mut(&mut self) -> &mut Arena<Local> {
+        &mut self.locals
+    }
 }

--- a/src/module/memories.rs
+++ b/src/module/memories.rs
@@ -71,7 +71,9 @@ impl ModuleMemories {
 }
 
 impl Emit for ModuleMemories {
-    fn emit(&self, used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
+    type Extra = ();
+
+    fn emit(&self, _: &(), used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
         if used.memories.is_empty() {
             return;
         }

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -117,13 +117,13 @@ impl Module {
         let indices = &mut IdsToIndices::default();
         let mut module = elements::Module::new(vec![data]);
 
-        self.types.emit(&used, &mut module, indices);
-        self.imports.emit(&used, &mut module, indices);
-        self.tables.emit(&used, &mut module, indices);
-        self.memories.emit(&used, &mut module, indices);
-        self.globals.emit(&used, &mut module, indices);
-        self.funcs.emit(&used, &mut module, indices);
-        self.exports.emit(&used, &mut module, indices);
+        self.types.emit(&(), &used, &mut module, indices);
+        self.imports.emit(&(), &used, &mut module, indices);
+        self.tables.emit(&(), &used, &mut module, indices);
+        self.memories.emit(&(), &used, &mut module, indices);
+        self.globals.emit(&(), &used, &mut module, indices);
+        self.funcs.emit(&self.locals, &used, &mut module, indices);
+        self.exports.emit(&(), &used, &mut module, indices);
 
         // TODO: start section
         // TODO: element section

--- a/src/module/tables.rs
+++ b/src/module/tables.rs
@@ -83,7 +83,9 @@ impl ModuleTables {
 }
 
 impl Emit for ModuleTables {
-    fn emit(&self, used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
+    type Extra = ();
+
+    fn emit(&self, _: &(), used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
         if used.tables.is_empty() {
             return;
         }

--- a/src/module/types.rs
+++ b/src/module/types.rs
@@ -65,7 +65,9 @@ impl ModuleTypes {
 }
 
 impl Emit for ModuleTypes {
-    fn emit(&self, used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
+    type Extra = ();
+
+    fn emit(&self, _: &(), used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
         if used.types.is_empty() {
             return;
         }

--- a/walrus-tests/tests/round_trip/fac.wat
+++ b/walrus-tests/tests/round_trip/fac.wat
@@ -33,21 +33,21 @@
 ;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32 i32)
 ;; NEXT:      block  ;; label = @1
-;; NEXT:        local.get 0
-;; NEXT:        local.set 1
+;; NEXT:        local.get 1
+;; NEXT:        local.set 0
 ;; NEXT:        loop  ;; label = @2
-;; NEXT:          local.get 0
+;; NEXT:          local.get 1
 ;; NEXT:          i32.eqz
 ;; NEXT:          br_if 1 (;@1;)
+;; NEXT:          local.get 0
 ;; NEXT:          local.get 1
-;; NEXT:          local.get 0
 ;; NEXT:          i32.mul
-;; NEXT:          local.set 1
-;; NEXT:          local.get 0
+;; NEXT:          local.set 0
+;; NEXT:          local.get 1
 ;; NEXT:          i32.const 1
 ;; NEXT:          i32.sub
-;; NEXT:          local.set 0
+;; NEXT:          local.set 1
 ;; NEXT:        end
 ;; NEXT:      end
-;; NEXT:      local.get 1)
+;; NEXT:      local.get 0)
 ;; NEXT:    (export "fac" (func 0)))

--- a/walrus-tests/tests/round_trip/used-local-in-local.wat
+++ b/walrus-tests/tests/round_trip/used-local-in-local.wat
@@ -9,5 +9,5 @@
 
 ;; CHECK: (func
 ;; NEXT:    (local i32 i32)
-;; NEXT:    local.get 0
-;; NEXT:    local.set 1)
+;; NEXT:    local.get 1
+;; NEXT:    local.set 0)


### PR DESCRIPTION
This is auxiliary information available in other tables, so let's just
keep a `LocalId` there. This involved tweaking the emission code to
ensure the table of locals made its way all the way down to function emission.

Closes #10