### PR TITLE
Add support for element segments and `CallIndirect`

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -11,6 +11,8 @@ use crate::module::functions::FunctionId;
 use crate::module::functions::{DisplayExpr, DotExpr};
 use crate::module::globals::GlobalId;
 use crate::module::memories::MemoryId;
+use crate::module::tables::TableId;
+use crate::ty::TypeId;
 use crate::ty::ValType;
 use id_arena::Id;
 use std::fmt;
@@ -129,6 +131,18 @@ pub enum Expr {
     Call {
         /// The function being invoked.
         func: FunctionId,
+        /// The arguments to the function.
+        args: Box<[ExprId]>,
+    },
+
+    /// `call_indirect`
+    CallIndirect {
+        /// The type signature of the function we're calling
+        ty: TypeId,
+        /// The table which `func` below is indexing into
+        table: TableId,
+        /// The index of the function we're invoking
+        func: ExprId,
         /// The arguments to the function.
         args: Box<[ExprId]>,
     },
@@ -341,6 +355,7 @@ impl Expr {
             | Expr::BrIf(..)
             | Expr::IfElse(..)
             | Expr::MemorySize(..)
+            | Expr::CallIndirect(..)
             | Expr::Drop(..) => false,
         }
     }

--- a/src/module/elements.rs
+++ b/src/module/elements.rs
@@ -3,7 +3,7 @@
 use crate::error::Result;
 use crate::module::emit::{Emit, IdsToIndices};
 use crate::module::functions::FunctionId;
-use crate::module::tables::TableId;
+use crate::module::tables::{ModuleTables, TableKind};
 use crate::module::Module;
 use crate::passes::Used;
 use id_arena::{Arena, Id};
@@ -23,16 +23,17 @@ pub struct Element {
 /// used as function pointers.
 #[derive(Debug, Default)]
 pub struct ModuleElements {
-    active: HashMap<TableId, Vec<Option<FunctionId>>>,
-    passive: Arena<Element>,
+    elements: Arena<Element>,
     index_to_element_id: HashMap<u32, ElementId>,
 }
 
 impl ModuleElements {
     /// Parses a raw was section into a fully-formed `ModuleElements` instance.
-    pub fn parse(module: &Module, section: &elements::ElementSection) -> Result<ModuleElements> {
-        let mut active = HashMap::new();
-        let mut passive = Arena::new();
+    pub fn parse(
+        module: &mut Module,
+        section: &elements::ElementSection,
+    ) -> Result<ModuleElements> {
+        let mut elements = Arena::new();
         let mut index_to_element_id = HashMap::new();
 
         for (i, segment) in section.entries().iter().enumerate() {
@@ -44,8 +45,8 @@ impl ModuleElements {
                         None => failure::bail!("invalid segment initialization"),
                     }
                 }
-                let id = passive.next_id();
-                let ret = passive.alloc(Element { members: list });
+                let id = elements.next_id();
+                let ret = elements.alloc(Element { members: list });
                 debug_assert_eq!(id, ret);
                 index_to_element_id.insert(i as u32, id);
                 continue;
@@ -55,7 +56,10 @@ impl ModuleElements {
                 .tables
                 .table_for_index(segment.index())
                 .ok_or_else(|| failure::format_err!("invalid table index"))?;
-            let list = active.entry(table).or_insert(Vec::new());
+            let list = match &mut module.tables.get_mut(table).kind {
+                TableKind::Function(list) => list,
+            };
+
             let offset = segment.offset().as_ref().unwrap();
             if offset.code().len() != 2 {
                 failure::bail!("invalid initialization expression");
@@ -82,8 +86,7 @@ impl ModuleElements {
         }
 
         Ok(ModuleElements {
-            active,
-            passive,
+            elements,
             index_to_element_id,
         })
     }
@@ -92,32 +95,36 @@ impl ModuleElements {
     pub fn element_for_index(&self, index: u32) -> Option<ElementId> {
         self.index_to_element_id.get(&index).cloned()
     }
-
-    /// Get the list of elements used to initialize the provided table
-    pub fn elements(&self, table: TableId) -> &[Option<FunctionId>] {
-        self.active.get(&table).map(|x| &x[..]).unwrap_or(&[])
-    }
 }
 
 impl Emit for ModuleElements {
-    type Extra = ();
+    type Extra = ModuleTables;
 
-    fn emit(&self, _: &(), used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
+    fn emit(
+        &self,
+        tables: &ModuleTables,
+        used: &Used,
+        module: &mut elements::Module,
+        indices: &mut IdsToIndices,
+    ) {
         let mut segments = Vec::new();
 
         // Sort table ids for a deterministic emission for now, eventually we
         // may want some sort of sorting heuristic here.
-        let mut active = self.active.keys().cloned().collect::<Vec<_>>();
+        let mut active = tables
+            .iter()
+            .filter(|t| used.tables.contains(&t.id()))
+            .filter_map(|t| match &t.kind {
+                TableKind::Function(list) => Some((t.id(), list)),
+            })
+            .collect::<Vec<_>>();
         active.sort();
 
         // Append segments as we find them for all table initializers. We can
         // skip initializers for unused tables, and othrewise we just want to
         // create an initializer for each contiguous chunk of function indices.
-        for table in active {
-            if !used.tables.contains(&table) {
-                continue;
-            }
-            let table_index = indices.get_table_index(table);
+        for (table_id, initializer) in active {
+            let table_index = indices.get_table_index(table_id);
 
             let mut add = |offset: usize, members: Vec<u32>| {
                 let code = vec![
@@ -135,7 +142,7 @@ impl Emit for ModuleElements {
 
             let mut offset = 0;
             let mut cur = Vec::new();
-            for (i, item) in self.active[&table].iter().enumerate() {
+            for (i, item) in initializer.iter().enumerate() {
                 match item {
                     Some(item) => {
                         if cur.len() == 0 {
@@ -161,7 +168,7 @@ impl Emit for ModuleElements {
         // may want to sort this more intelligently in the future. Othrewise
         // emitting a segment here is in general much simpler than above as we
         // know there are no holes.
-        for (id, segment) in self.passive.iter() {
+        for (id, segment) in self.elements.iter() {
             if !used.elements.contains(&id) {
                 continue;
             }

--- a/src/module/elements.rs
+++ b/src/module/elements.rs
@@ -1,0 +1,185 @@
+//! Table elements within a wasm module.
+
+use crate::error::Result;
+use crate::module::emit::{Emit, IdsToIndices};
+use crate::module::functions::FunctionId;
+use crate::module::tables::TableId;
+use crate::module::Module;
+use crate::passes::Used;
+use id_arena::{Arena, Id};
+use parity_wasm::elements;
+use std::collections::HashMap;
+
+/// A passive element segment identifier
+pub type ElementId = Id<Element>;
+
+/// A passive segment which contains a list of functions
+#[derive(Debug)]
+pub struct Element {
+    members: Vec<FunctionId>,
+}
+
+/// All element segments of a wasm module, used to initialize `anyfunc` tables,
+/// used as function pointers.
+#[derive(Debug, Default)]
+pub struct ModuleElements {
+    active: HashMap<TableId, Vec<Option<FunctionId>>>,
+    passive: Arena<Element>,
+    index_to_element_id: HashMap<u32, ElementId>,
+}
+
+impl ModuleElements {
+    /// Parses a raw was section into a fully-formed `ModuleElements` instance.
+    pub fn parse(module: &Module, section: &elements::ElementSection) -> Result<ModuleElements> {
+        let mut active = HashMap::new();
+        let mut passive = Arena::new();
+        let mut index_to_element_id = HashMap::new();
+
+        for (i, segment) in section.entries().iter().enumerate() {
+            if segment.passive() {
+                let mut list = Vec::with_capacity(segment.members().len());
+                for &func in segment.members() {
+                    match module.funcs.function_for_index(func) {
+                        Some(id) => list.push(id),
+                        None => failure::bail!("invalid segment initialization"),
+                    }
+                }
+                let id = passive.next_id();
+                let ret = passive.alloc(Element { members: list });
+                debug_assert_eq!(id, ret);
+                index_to_element_id.insert(i as u32, id);
+                continue;
+            }
+
+            let table = module
+                .tables
+                .table_for_index(segment.index())
+                .ok_or_else(|| failure::format_err!("invalid table index"))?;
+            let list = active.entry(table).or_insert(Vec::new());
+            let offset = segment.offset().as_ref().unwrap();
+            if offset.code().len() != 2 {
+                failure::bail!("invalid initialization expression");
+            }
+            match offset.code()[1] {
+                elements::Instruction::End => {}
+                _ => failure::bail!("invalid initialization expression"),
+            }
+            let offset = match offset.code()[0] {
+                elements::Instruction::I32Const(n) => n as usize,
+                _ => failure::bail!("invalid initialization expression"),
+            };
+
+            for (i, &func) in segment.members().iter().enumerate() {
+                let id = match module.funcs.function_for_index(func) {
+                    Some(i) => i,
+                    None => failure::bail!("invalid segment initialization"),
+                };
+                while i + offset + 1 > list.len() {
+                    list.push(None);
+                }
+                list[i + offset] = Some(id);
+            }
+        }
+
+        Ok(ModuleElements {
+            active,
+            passive,
+            index_to_element_id,
+        })
+    }
+
+    /// Get the element for the given index in the input wasm, if any exists.
+    pub fn element_for_index(&self, index: u32) -> Option<ElementId> {
+        self.index_to_element_id.get(&index).cloned()
+    }
+
+    /// Get the list of elements used to initialize the provided table
+    pub fn elements(&self, table: TableId) -> &[Option<FunctionId>] {
+        self.active.get(&table).map(|x| &x[..]).unwrap_or(&[])
+    }
+}
+
+impl Emit for ModuleElements {
+    type Extra = ();
+
+    fn emit(&self, _: &(), used: &Used, module: &mut elements::Module, indices: &mut IdsToIndices) {
+        let mut segments = Vec::new();
+
+        // Sort table ids for a deterministic emission for now, eventually we
+        // may want some sort of sorting heuristic here.
+        let mut active = self.active.keys().cloned().collect::<Vec<_>>();
+        active.sort();
+
+        // Append segments as we find them for all table initializers. We can
+        // skip initializers for unused tables, and othrewise we just want to
+        // create an initializer for each contiguous chunk of function indices.
+        for table in active {
+            if !used.tables.contains(&table) {
+                continue;
+            }
+            let table_index = indices.get_table_index(table);
+
+            let mut add = |offset: usize, members: Vec<u32>| {
+                let code = vec![
+                    elements::Instruction::I32Const(offset as i32),
+                    elements::Instruction::End,
+                ];
+                let init = elements::InitExpr::new(code);
+                segments.push(elements::ElementSegment::new(
+                    table_index,
+                    Some(init),
+                    members,
+                    false,
+                ));
+            };
+
+            let mut offset = 0;
+            let mut cur = Vec::new();
+            for (i, item) in self.active[&table].iter().enumerate() {
+                match item {
+                    Some(item) => {
+                        if cur.len() == 0 {
+                            offset = i;
+                        }
+                        cur.push(indices.get_func_index(*item));
+                    }
+                    None => {
+                        if cur.len() > 0 {
+                            add(offset, cur);
+                        }
+                        cur = Vec::new();
+                    }
+                }
+            }
+
+            if cur.len() > 0 {
+                add(offset, cur);
+            }
+        }
+
+        // After all the active segments are added add passive segments next. We
+        // may want to sort this more intelligently in the future. Othrewise
+        // emitting a segment here is in general much simpler than above as we
+        // know there are no holes.
+        for (id, segment) in self.passive.iter() {
+            if !used.elements.contains(&id) {
+                continue;
+            }
+            let index = segments.len() as u32;
+            indices.set_element_index(id, index);
+
+            let members = segment
+                .members
+                .iter()
+                .map(|id| indices.get_func_index(*id))
+                .collect();
+            segments.push(elements::ElementSegment::new(0, None, members, true));
+        }
+
+        if segments.len() > 0 {
+            let elements = elements::ElementSection::with_entries(segments);
+            let elements = elements::Section::Element(elements);
+            module.sections_mut().push(elements);
+        }
+    }
+}

--- a/src/module/emit.rs
+++ b/src/module/emit.rs
@@ -4,6 +4,7 @@
 //! `parity_wasm::elements` types.
 
 use crate::ir::LocalId;
+use crate::module::elements::ElementId;
 use crate::module::functions::FunctionId;
 use crate::module::globals::GlobalId;
 use crate::module::imports::ImportId;
@@ -47,6 +48,7 @@ pub(crate) struct IdsToIndices {
     globals: HashMap<GlobalId, u32>,
     locals: HashMap<LocalId, u32>,
     memories: HashMap<MemoryId, u32>,
+    elements: HashMap<ElementId, u32>,
 }
 
 macro_rules! define_get_set_index {
@@ -54,6 +56,7 @@ macro_rules! define_get_set_index {
         impl IdsToIndices {
             /// Get the index for the given identifier.
             #[inline]
+            #[allow(dead_code)] // not everything is used just yet
             pub(crate) fn $get_name(&self, id: $id_ty) -> u32 {
                 self.$member.get(&id).cloned().expect(
                     "Should never try and get the index for an identifier that has not already had \
@@ -79,3 +82,4 @@ define_get_set_index!(get_func_index, set_func_index, FunctionId, funcs);
 define_get_set_index!(get_global_index, set_global_index, GlobalId, globals);
 define_get_set_index!(get_local_index, set_local_index, LocalId, locals);
 define_get_set_index!(get_memory_index, set_memory_index, MemoryId, memories);
+define_get_set_index!(get_element_index, set_element_index, ElementId, elements);

--- a/src/module/functions/local_function/context.rs
+++ b/src/module/functions/local_function/context.rs
@@ -110,11 +110,16 @@ impl<'a> FunctionContext<'a> {
         impl_pop_operand_expected(&mut self.operands, &mut self.controls, expected)
     }
 
-    pub fn push_operands<E>(&mut self, types: &[ValType], exprs: &[E])
+    pub fn push_operands<E>(&mut self, types: &[ValType], exprs: &[E], expr: ExprId)
     where
         E: Copy + Into<ExprId>,
     {
-        impl_push_operands(&mut self.operands, types, exprs)
+        assert_eq!(types.len(), exprs.len());
+        if types.is_empty() && self.controls.len() > 0 {
+            self.add_to_current_frame_block(expr);
+        } else {
+            impl_push_operands(&mut self.operands, types, exprs)
+        }
     }
 
     pub fn pop_operands(&mut self, expected: &[ValType]) -> Result<Vec<ExprId>> {

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -137,6 +137,17 @@ impl Emit<'_> {
                 self.emit(elements::Instruction::Call(idx))
             }
 
+            CallIndirect(e) => {
+                for x in e.args.iter() {
+                    self.visit(*x);
+                }
+                self.visit(e.func);
+                let idx = self.indices.get_type_index(e.ty);
+                let table = self.indices.get_table_index(e.table);
+                assert!(table < 256); // TODO: update parity-wasm to accept u32
+                self.emit(elements::Instruction::CallIndirect(idx, table as u8))
+            }
+
             LocalGet(e) => {
                 let idx = self.indices.get_local_index(e.local);
                 self.emit(elements::Instruction::GetLocal(idx))

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -380,17 +380,17 @@ fn validate_instruction<'a>(
             ctx.push_operands(&result_tys, &result_exprs, expr.into());
         }
         Instruction::CallIndirect(type_idx, table_idx) => {
-            let type_id = ctx
-                .module
-                .types
-                .type_for_index(*type_idx)
-                .ok_or_else(|| format_err!("invalid type index in `call_indirect`"))?;
+            let type_id = ctx.module.types.type_for_index(*type_idx).ok_or_else(|| {
+                format_err!("invalid type index in `call_indirect: {}`", type_idx)
+            })?;
             let ty = ctx.module.types.types()[type_id].clone();
             let table = ctx
                 .module
                 .tables
                 .table_for_index((*table_idx) as u32)
-                .ok_or_else(|| format_err!("invalid index in `call_indirect`"))?;
+                .ok_or_else(|| {
+                    format_err!("invalid table index in `call_indirect`: {}", table_idx)
+                })?;
             let (_, func) = ctx.pop_operand_expected(Some(ValType::I32))?;
             let args = ctx.pop_operands(ty.params())?.into_boxed_slice();
             let expr = ctx.func.alloc(CallIndirect {

--- a/src/module/functions/mod.rs
+++ b/src/module/functions/mod.rs
@@ -334,7 +334,7 @@ impl Emit for ModuleFunctions {
         }
 
         assert_eq!(funcs.len(), codes.len());
-        if codes.len() == 0 {
+        if codes.is_empty() {
             return;
         }
 

--- a/src/module/functions/mod.rs
+++ b/src/module/functions/mod.rs
@@ -266,10 +266,6 @@ impl Emit for ModuleFunctions {
         module: &mut elements::Module,
         indices: &mut IdsToIndices,
     ) {
-        if used.funcs.is_empty() {
-            return;
-        }
-
         // Partition used functions into two sets: imported and local
         // functions. Find the size of each local function. Sort imported
         // functions in order so that we can get their index in the function
@@ -277,19 +273,20 @@ impl Emit for ModuleFunctions {
         let mut sizes = HashMap::new();
         let mut imports = BTreeMap::new();
         for (id, f) in &self.arena {
-            if used.funcs.contains(&id) {
-                match f.kind {
-                    FunctionKind::Local(ref l) => {
-                        let old = sizes.insert(id, l.size());
-                        assert!(old.is_none());
-                    }
-                    FunctionKind::Import(ref i) => {
-                        let idx = indices.get_import_index(i.import);
-                        let old = imports.insert(idx, id);
-                        assert!(old.is_none());
-                    }
-                    FunctionKind::Uninitialized(_) => unreachable!(),
+            if !used.funcs.contains(&id) {
+                continue;
+            }
+            match f.kind {
+                FunctionKind::Local(ref l) => {
+                    let old = sizes.insert(id, l.size());
+                    assert!(old.is_none());
                 }
+                FunctionKind::Import(ref i) => {
+                    let idx = indices.get_import_index(i.import);
+                    let old = imports.insert(idx, id);
+                    assert!(old.is_none());
+                }
+                FunctionKind::Uninitialized(_) => unreachable!(),
             }
         }
 
@@ -334,6 +331,11 @@ impl Emit for ModuleFunctions {
             let instructions = func.emit_instructions(indices);
             let instructions = elements::Instructions::new(instructions);
             codes.push(elements::FuncBody::new(locals, instructions));
+        }
+
+        assert_eq!(funcs.len(), codes.len());
+        if codes.len() == 0 {
+            return;
         }
 
         let funcs = elements::FunctionSection::with_entries(funcs);

--- a/src/module/locals.rs
+++ b/src/module/locals.rs
@@ -54,6 +54,7 @@ impl ModuleLocals {
     }
 
     /// Get the set of locals for this module.
+    #[allow(dead_code)]
     pub(crate) fn locals_mut(&mut self) -> &mut Arena<Local> {
         &mut self.locals
     }

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -1,5 +1,6 @@
 //! A high-level API for manipulating wasm modules.
 
+pub mod elements;
 pub(crate) mod emit;
 pub mod exports;
 pub mod functions;
@@ -10,6 +11,7 @@ pub mod memories;
 pub mod tables;
 pub mod types;
 
+use self::elements::ModuleElements;
 use self::emit::{Emit, IdsToIndices};
 use self::exports::ModuleExports;
 use self::functions::Function;
@@ -23,7 +25,7 @@ use self::types::ModuleTypes;
 use crate::error::Result;
 use crate::passes;
 use failure::ResultExt;
-use parity_wasm::elements;
+use parity_wasm::elements as parity;
 use std::fs;
 use std::path::Path;
 
@@ -39,7 +41,8 @@ pub struct Module {
     pub(crate) exports: ModuleExports,
     pub(crate) memories: ModuleMemories,
     // TODO: make this an internal type, not a parity-wasm type
-    pub(crate) data: elements::DataSection,
+    pub(crate) data: parity::DataSection,
+    pub(crate) elements: ModuleElements,
 }
 
 impl Module {
@@ -55,7 +58,7 @@ impl Module {
     pub fn from_buffer(mut wasm: &[u8]) -> Result<Module> {
         use parity_wasm::elements::Deserialize;
 
-        let module = elements::Module::deserialize(&mut wasm)?;
+        let module = parity::Module::deserialize(&mut wasm)?;
         if wasm.len() > 0 {
             failure::bail!("invalid wasm file");
         }
@@ -77,14 +80,13 @@ impl Module {
                 Section::Global(s) => ret.globals = ModuleGlobals::parse(&module, s)?,
                 Section::Function(s) => ret.declare_local_functions(s)?,
                 Section::Code(s) => ret.parse_local_functions(&module, s)?,
-
                 Section::Export(s) => ret.exports = ModuleExports::parse(&ret, s)?,
+                Section::Element(s) => ret.elements = ModuleElements::parse(&ret, s)?,
 
                 // TODO: handle these
                 Section::Unparsed { .. } => {}
                 Section::Custom(_) => {}
                 Section::Start(_) => {}
-                Section::Element(_) => {}
                 Section::Name(_) => {}
                 Section::Reloc(_) => {}
             }
@@ -112,10 +114,10 @@ impl Module {
     pub fn emit_wasm(&self) -> Result<Vec<u8>> {
         let roots = self.exports.arena.iter().map(|(id, _)| id);
         let used = passes::Used::new(self, roots);
-        let data = elements::Section::Data(self.data.clone());
+        let data = parity::Section::Data(self.data.clone());
 
         let indices = &mut IdsToIndices::default();
-        let mut module = elements::Module::new(vec![data]);
+        let mut module = parity::Module::new(vec![data]);
 
         self.types.emit(&(), &used, &mut module, indices);
         self.imports.emit(&(), &used, &mut module, indices);
@@ -124,30 +126,29 @@ impl Module {
         self.globals.emit(&(), &used, &mut module, indices);
         self.funcs.emit(&self.locals, &used, &mut module, indices);
         self.exports.emit(&(), &used, &mut module, indices);
-
         // TODO: start section
-        // TODO: element section
+        self.elements.emit(&(), &used, &mut module, indices);
 
         module.sections_mut().sort_by_key(|s| match s {
-            elements::Section::Type(_) => 1,
-            elements::Section::Import(_) => 2,
-            elements::Section::Function(_) => 3,
-            elements::Section::Table(_) => 4,
-            elements::Section::Memory(_) => 5,
-            elements::Section::Global(_) => 6,
-            elements::Section::Export(_) => 7,
-            elements::Section::Start(_) => 8,
-            elements::Section::Element(_) => 9,
-            elements::Section::Code(_) => 10,
-            elements::Section::Data(_) => 11,
+            parity::Section::Type(_) => 1,
+            parity::Section::Import(_) => 2,
+            parity::Section::Function(_) => 3,
+            parity::Section::Table(_) => 4,
+            parity::Section::Memory(_) => 5,
+            parity::Section::Global(_) => 6,
+            parity::Section::Export(_) => 7,
+            parity::Section::Start(_) => 8,
+            parity::Section::Element(_) => 9,
+            parity::Section::Code(_) => 10,
+            parity::Section::Data(_) => 11,
 
-            elements::Section::Custom(_)
-            | elements::Section::Unparsed { .. }
-            | elements::Section::Reloc(_)
-            | elements::Section::Name(_) => 12,
+            parity::Section::Custom(_)
+            | parity::Section::Unparsed { .. }
+            | parity::Section::Reloc(_)
+            | parity::Section::Name(_) => 12,
         });
         let buffer =
-            elements::serialize(module).context("failed to serialize wasm module to file")?;
+            parity::serialize(module).context("failed to serialize wasm module to file")?;
         Ok(buffer)
     }
 }

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -81,7 +81,7 @@ impl Module {
                 Section::Function(s) => ret.declare_local_functions(s)?,
                 Section::Code(s) => ret.parse_local_functions(&module, s)?,
                 Section::Export(s) => ret.exports = ModuleExports::parse(&ret, s)?,
-                Section::Element(s) => ret.elements = ModuleElements::parse(&ret, s)?,
+                Section::Element(s) => ret.elements = ModuleElements::parse(&mut ret, s)?,
 
                 // TODO: handle these
                 Section::Unparsed { .. } => {}
@@ -127,7 +127,8 @@ impl Module {
         self.funcs.emit(&self.locals, &used, &mut module, indices);
         self.exports.emit(&(), &used, &mut module, indices);
         // TODO: start section
-        self.elements.emit(&(), &used, &mut module, indices);
+        self.elements
+            .emit(&self.tables, &used, &mut module, indices);
 
         module.sections_mut().sort_by_key(|s| match s {
             parity::Section::Type(_) => 1,

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -5,10 +5,9 @@ use crate::module::functions::{FunctionId, FunctionKind, LocalFunction};
 use crate::module::globals::GlobalId;
 use crate::module::imports::ImportId;
 use crate::module::memories::MemoryId;
-use crate::module::tables::TableId;
+use crate::module::tables::{TableId, TableKind};
 use crate::module::Module;
 use crate::ty::TypeId;
-use parity_wasm::elements;
 use std::collections::HashSet;
 
 /// Finds the things within a module that are used.
@@ -80,9 +79,9 @@ impl Used {
                 }
                 ItemToVisit::Table(t) => {
                     let table = &module.tables.arena[t];
-                    match table.ty {
-                        elements::TableElementType::AnyFunc => {
-                            for id in module.elements.elements(t) {
+                    match &table.kind {
+                        TableKind::Function(list) => {
+                            for id in list {
                                 if let Some(id) = id {
                                     stack.push_func(*id);
                                 }

--- a/src/validation_context.rs
+++ b/src/validation_context.rs
@@ -14,7 +14,7 @@ use std::u32;
 /// https://webassembly.github.io/spec/core/valid/conventions.html#contexts
 #[derive(Debug)]
 pub struct ValidationContext<'a> {
-    types: ChunkList<'a, elements::FunctionType>,
+    pub(crate) types: ChunkList<'a, elements::FunctionType>,
     pub(crate) funcs: ChunkList<'a, elements::FunctionType>,
     tables: ChunkList<'a, elements::TableType>,
     mems: ChunkList<'a, elements::MemoryType>,

--- a/walrus-derive/src/lib.rs
+++ b/walrus-derive/src/lib.rs
@@ -497,6 +497,11 @@ fn create_visit(variants: &[WalrusVariant]) -> impl quote::ToTokens {
                 // ...
             }
 
+            /// Visit `TypeId`
+            fn visit_type_id(&mut self, ty: &crate::ty::TypeId) {
+                // ...
+            }
+
             /// Visit `Value`.
             fn visit_value(&mut self, value: &crate::ir::Value) {
                 // ...
@@ -623,13 +628,13 @@ fn create_matchers(variants: &[WalrusVariant]) -> impl quote::ToTokens {
                 }
 
                 impl< #( #generics ),* > Matcher for #name < #( #generic_tys ),* > {
-                    fn is_match(&self, func: &LocalFunction, expr: &Expr) -> bool {
+                    fn is_match(&self, local_func: &LocalFunction, expr: &Expr) -> bool {
                         match expr {
                             Expr::#expr( #expr #pattern ) => {
                                 true #(
                                     && #self_args.is_match(
-                                        func,
-                                        &func.exprs[*#args]
+                                        local_func,
+                                        &local_func.exprs[*#args]
                                     )
                                 )*
                             }
@@ -710,6 +715,10 @@ fn create_display(variants: &[WalrusVariant]) -> impl quote::ToTokens {
                 self.id(*function);
             }
 
+            fn visit_type_id(&mut self, ty: &crate::ty::TypeId) {
+                self.id(*ty);
+            }
+
             fn visit_value(&mut self, value: &crate::ir::Value) {
                 self.f.push_str(" ");
                 self.f.push_str(&value.to_string());
@@ -788,6 +797,10 @@ fn create_dot(variants: &[WalrusVariant]) -> impl quote::ToTokens {
 
             fn visit_function_id(&mut self, function: &crate::module::functions::FunctionId) {
                 self.id(*function);
+            }
+
+            fn visit_type_id(&mut self, ty: &crate::ty::TypeId) {
+                self.id(*ty);
             }
 
             fn visit_value(&mut self, value: &crate::ir::Value) {

--- a/walrus-tests-utils/src/lib.rs
+++ b/walrus-tests-utils/src/lib.rs
@@ -31,8 +31,13 @@ pub fn wat2wasm(path: &Path) -> Vec<u8> {
     let mut cmd = Command::new("wat2wasm");
     cmd.arg(path).arg("-o").arg(file.path());
     println!("running: {:?}", cmd);
-    let status = cmd.status().expect("should spawn wat2wasm OK");
-    assert!(status.success(), "should run wat2wasm OK");
+    let output = cmd.output().expect("should spawn wat2wasm OK");
+
+    if !output.status.success() {
+        println!("status: {}", output.status);
+        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        panic!("expected ok");
+    }
 
     fs::read(file.path()).unwrap()
 }

--- a/walrus-tests/tests/round_trip/elem-segments-1.wat
+++ b/walrus-tests/tests/round_trip/elem-segments-1.wat
@@ -1,0 +1,8 @@
+(module
+  (table 1 anyfunc)
+  (func)
+  (elem (i32.const 1) 0)
+  (export "foo" (table 0))
+  )
+
+;; CHECK: (elem (;0;) (i32.const 1) 0)

--- a/walrus-tests/tests/round_trip/elem-segments-2.wat
+++ b/walrus-tests/tests/round_trip/elem-segments-2.wat
@@ -1,0 +1,9 @@
+(module
+  (table 1 anyfunc)
+  (func)
+  (elem (i32.const 1) 0)
+  (elem (i32.const 2) 0)
+  (export "foo" (table 0))
+  )
+
+;; CHECK: (elem (;0;) (i32.const 1) 0 0)

--- a/walrus-tests/tests/round_trip/elem-segments-3.wat
+++ b/walrus-tests/tests/round_trip/elem-segments-3.wat
@@ -1,0 +1,10 @@
+(module
+  (table 1 anyfunc)
+  (func)
+  (elem (i32.const 1) 0)
+  (elem (i32.const 3) 0)
+  (export "foo" (table 0))
+  )
+
+;; CHECK: (elem (;0;) (i32.const 1) 0)
+;; NEXT:  (elem (;1;) (i32.const 3) 0)

--- a/walrus-tests/tests/round_trip/keep-elem-segments.wat
+++ b/walrus-tests/tests/round_trip/keep-elem-segments.wat
@@ -1,0 +1,25 @@
+(module
+  (type (func))
+
+  (table anyfunc (elem 1))
+
+  (func
+    i32.const 0
+    call_indirect
+    )
+
+  (func)
+
+  (export "foo" (func 0))
+  )
+
+;; CHECK: (module
+;; NEXT:    (type (;0;) (func))
+;; NEXT:    (func (;0;) (type 0)
+;; NEXT:      i32.const 0
+;; NEXT:      call_indirect (type 0))
+;; NEXT:    (func (;1;) (type 0))
+;; NEXT:    (table (;0;) 1 1 anyfunc)
+;; NEXT:    (export "foo" (func 0))
+;; NEXT:    (elem (;0;) (i32.const 0) 1))
+


### PR DESCRIPTION
Lots of stuff added here, sort of by accident:

* `CallIndirect` support
* Parsing and serializing the elements wasm section
* Liveness tracking of passive segments
* Liveness tracking through function tables of retained function
  pointers
* Fixed parsing of `Call` with zero return values