### PR TITLE
Add dedicated constant value processing

### DIFF
--- a/src/const_value.rs
+++ b/src/const_value.rs
@@ -1,0 +1,52 @@
+//! Handling wasm constant values
+
+use crate::error::Result;
+use crate::ir::Value;
+use crate::module::emit::IdsToIndices;
+use crate::module::globals::GlobalId;
+use failure::bail;
+use parity_wasm::elements::{self, Instruction};
+
+/// A constant which is produced in WebAssembly, typically used in global
+/// initializers or element/data offsets.
+#[derive(Debug)]
+pub enum Const {
+    /// An immediate constant value
+    Value(Value),
+    /// A constant value referenced by the global specified
+    Global(GlobalId),
+}
+
+impl Const {
+    pub(crate) fn eval(init: &elements::InitExpr) -> Result<Const> {
+        let instrs = init.code();
+        if instrs.len() != 2 {
+            bail!("invalid constant expression");
+        }
+        match instrs[1] {
+            Instruction::End => {}
+            _ => bail!("invalid constant expression"),
+        }
+        match instrs[0] {
+            Instruction::I32Const(n) => Ok(Const::Value(Value::I32(n))),
+            Instruction::I64Const(n) => Ok(Const::Value(Value::I64(n))),
+            Instruction::F32Const(n) => Ok(Const::Value(Value::F32(f32::from_bits(n)))),
+            Instruction::F64Const(n) => Ok(Const::Value(Value::F64(f64::from_bits(n)))),
+            _ => bail!("invalid constant expression"),
+        }
+    }
+
+    pub(crate) fn emit_instructions(&self, indices: &IdsToIndices) -> elements::InitExpr {
+        let mut instrs = Vec::with_capacity(2);
+        instrs.push(match *self {
+            Const::Value(Value::I32(n)) => Instruction::I32Const(n),
+            Const::Value(Value::I64(n)) => Instruction::I64Const(n),
+            Const::Value(Value::F32(n)) => Instruction::F32Const(n.to_bits()),
+            Const::Value(Value::F64(n)) => Instruction::F64Const(n.to_bits()),
+            Const::Value(Value::V128(_n)) => unimplemented!(),
+            Const::Global(id) => Instruction::GetGlobal(indices.get_global_index(id)),
+        });
+        instrs.push(Instruction::End);
+        elements::InitExpr::new(instrs)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod arena_set;
 mod chunk_list;
+pub mod const_value;
 pub mod dot;
 pub mod error;
 pub mod ir;

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -77,7 +77,7 @@ impl Module {
                 }
                 Section::Table(s) => ret.tables = ModuleTables::parse(s),
                 Section::Memory(s) => ret.memories = ModuleMemories::parse(s),
-                Section::Global(s) => ret.globals = ModuleGlobals::parse(&module, s)?,
+                Section::Global(s) => ret.globals = ModuleGlobals::parse(s)?,
                 Section::Function(s) => ret.declare_local_functions(s)?,
                 Section::Code(s) => ret.parse_local_functions(&module, s)?,
                 Section::Export(s) => ret.exports = ModuleExports::parse(&ret, s)?,

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -82,8 +82,14 @@ impl Used {
                 let table = &module.tables.arena[t];
                 match &table.kind {
                     TableKind::Function(list) => {
-                        for id in list {
+                        for id in list.elements.iter() {
                             if let Some(id) = id {
+                                stack.push_func(*id);
+                            }
+                        }
+                        for (global, list) in list.relative_elements.iter() {
+                            stack.used.globals.insert(*global);
+                            for id in list {
                                 stack.push_func(*id);
                             }
                         }


### PR DESCRIPTION
This commit unifies the paths in handling offsets in table elements as
well as initialization expressions in globals. A new `Const` type is
added and a `Const::eval` function is added for transforming an
`InitExpr`.

Notably `Const::Global` exists for non-constant values, and although we
don't parse it just yet support should be plumbed through.