### PR TITLE
Overhaul how imports are handled

### DIFF
--- a/src/arena_set.rs
+++ b/src/arena_set.rs
@@ -20,6 +20,7 @@ impl<T: Clone + Eq + Hash> ArenaSet<T> {
     }
 
     /// Construct a new set with the given capacity.
+    #[allow(unused)]
     pub fn with_capacity(capacity: usize) -> ArenaSet<T> {
         ArenaSet {
             arena: Arena::with_capacity(capacity),
@@ -45,6 +46,7 @@ impl<T: Clone + Eq + Hash> ArenaSet<T> {
 
     /// Get a shared reference to the item associated with the given id if it is
     /// in the set.
+    #[allow(unused)]
     pub fn get(&self, id: Id<T>) -> Option<&T> {
         self.arena.get(id)
     }

--- a/src/const_value.rs
+++ b/src/const_value.rs
@@ -1,8 +1,8 @@
 //! Handling wasm constant values
 
+use crate::emit::IdsToIndices;
 use crate::error::Result;
 use crate::ir::Value;
-use crate::module::emit::IdsToIndices;
 use crate::module::globals::GlobalId;
 use failure::bail;
 use parity_wasm::elements::{self, Instruction};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod arena_set;
 mod chunk_list;
 pub mod const_value;
 pub mod dot;
+mod emit;
 pub mod error;
 pub mod ir;
 pub mod module;

--- a/src/module/functions/local_function/context.rs
+++ b/src/module/functions/local_function/context.rs
@@ -3,6 +3,7 @@
 use crate::error::{ErrorKind, Result};
 use crate::ir::{Block, BlockId, BlockKind, ExprId};
 use crate::module::functions::{FunctionId, LocalFunction};
+use crate::module::parse::IndicesToIds;
 use crate::module::Module;
 use crate::ty::ValType;
 use crate::validation_context::ValidationContext;
@@ -45,6 +46,9 @@ pub struct FunctionContext<'a> {
     /// The module that we're adding a function for.
     pub module: &'a mut Module,
 
+    /// Mapping of indexes back to ids.
+    pub indices: &'a IndicesToIds,
+
     /// The arena id of `func`.
     pub func_id: FunctionId,
 
@@ -65,6 +69,7 @@ impl<'a> FunctionContext<'a> {
     /// Create a new function context.
     pub fn new(
         module: &'a mut Module,
+        indices: &'a IndicesToIds,
         func_id: FunctionId,
         func: &'a mut LocalFunction,
         validation: &'a ValidationContext<'a>,
@@ -73,6 +78,7 @@ impl<'a> FunctionContext<'a> {
     ) -> FunctionContext<'a> {
         FunctionContext {
             module,
+            indices,
             func_id,
             func,
             validation,
@@ -84,6 +90,7 @@ impl<'a> FunctionContext<'a> {
     pub fn nested<'b>(&'b mut self, validation: &'b ValidationContext<'b>) -> FunctionContext<'b> {
         FunctionContext {
             module: self.module,
+            indices: self.indices,
             func_id: self.func_id,
             func: self.func,
             validation,

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -1,5 +1,5 @@
+use crate::emit::IdsToIndices;
 use crate::ir::*;
-use crate::module::emit::IdsToIndices;
 use crate::module::functions::LocalFunction;
 use parity_wasm::elements;
 

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -1,28 +1,27 @@
 //! A high-level API for manipulating wasm modules.
 
 pub mod elements;
-pub(crate) mod emit;
 pub mod exports;
 pub mod functions;
 pub mod globals;
 pub mod imports;
 pub mod locals;
 pub mod memories;
+mod parse;
 pub mod tables;
 pub mod types;
 
-use self::elements::ModuleElements;
-use self::emit::{Emit, IdsToIndices};
-use self::exports::ModuleExports;
-use self::functions::Function;
-use self::functions::ModuleFunctions;
-use self::globals::ModuleGlobals;
-use self::imports::ModuleImports;
-use self::locals::ModuleLocals;
-use self::memories::ModuleMemories;
-use self::tables::ModuleTables;
-use self::types::ModuleTypes;
+use crate::emit::{Emit, EmitContext, IdsToIndices};
 use crate::error::Result;
+use crate::module::elements::ModuleElements;
+use crate::module::exports::ModuleExports;
+use crate::module::functions::{ModuleFunctions, Function};
+use crate::module::globals::ModuleGlobals;
+use crate::module::imports::ModuleImports;
+use crate::module::locals::ModuleLocals;
+use crate::module::memories::ModuleMemories;
+use crate::module::tables::ModuleTables;
+use crate::module::types::ModuleTypes;
 use crate::passes;
 use failure::ResultExt;
 use parity_wasm::elements as parity;
@@ -64,24 +63,22 @@ impl Module {
         }
 
         let mut ret = Module::default();
+        let mut indices = parse::IndicesToIds::default();
 
         for section in module.sections() {
             use parity_wasm::elements::Section;
 
             match section {
                 Section::Data(s) => ret.data = s.clone(),
-                Section::Type(s) => ret.types = ModuleTypes::parse(s),
-                Section::Import(s) => {
-                    ret.imports = ModuleImports::parse(&ret.types, s)?;
-                    ret.register_imported_functions();
-                }
-                Section::Table(s) => ret.tables = ModuleTables::parse(s),
-                Section::Memory(s) => ret.memories = ModuleMemories::parse(s),
-                Section::Global(s) => ret.globals = ModuleGlobals::parse(s)?,
-                Section::Function(s) => ret.declare_local_functions(s)?,
-                Section::Code(s) => ret.parse_local_functions(&module, s)?,
-                Section::Export(s) => ret.exports = ModuleExports::parse(&ret, s)?,
-                Section::Element(s) => ret.elements = ModuleElements::parse(&mut ret, s)?,
+                Section::Type(s) => ret.parse_types(s, &mut indices),
+                Section::Import(s) => ret.parse_imports(s, &mut indices)?,
+                Section::Table(s) => ret.parse_tables(s, &mut indices),
+                Section::Memory(s) => ret.parse_memories(s, &mut indices),
+                Section::Global(s) => ret.parse_globals(s, &mut indices)?,
+                Section::Function(s) => ret.declare_local_functions(s, &mut indices)?,
+                Section::Code(s) => ret.parse_local_functions(&module, s, &mut indices)?,
+                Section::Export(s) => ret.parse_exports(s, &mut indices)?,
+                Section::Element(s) => ret.parse_elements(s, &mut indices)?,
 
                 // TODO: handle these
                 Section::Unparsed { .. } => {}
@@ -93,11 +90,6 @@ impl Module {
         }
 
         Ok(ret)
-    }
-
-    /// Get a shared reference to this module's functions.
-    pub fn functions(&self) -> impl Iterator<Item = &Function> {
-        self.funcs.arena.iter().map(|(_, f)| f)
     }
 
     /// Emit this module into a `.wasm` file at the given path.
@@ -112,23 +104,28 @@ impl Module {
 
     /// Emit this module into an in-memory wasm buffer.
     pub fn emit_wasm(&self) -> Result<Vec<u8>> {
-        let roots = self.exports.arena.iter().map(|(id, _)| id);
-        let used = passes::Used::new(self, roots);
+        let roots = self.exports.iter();
+        let used = passes::Used::new(self, roots.map(|e| e.id()));
         let data = parity::Section::Data(self.data.clone());
 
         let indices = &mut IdsToIndices::default();
         let mut module = parity::Module::new(vec![data]);
 
-        self.types.emit(&(), &used, &mut module, indices);
-        self.imports.emit(&(), &used, &mut module, indices);
-        self.tables.emit(&(), &used, &mut module, indices);
-        self.memories.emit(&(), &used, &mut module, indices);
-        self.globals.emit(&(), &used, &mut module, indices);
-        self.funcs.emit(&self.locals, &used, &mut module, indices);
-        self.exports.emit(&(), &used, &mut module, indices);
+        let mut cx = EmitContext {
+            module: self,
+            indices,
+            used: &used,
+            dst: &mut module,
+        };
+        self.types.emit(&mut cx);
+        self.imports.emit(&mut cx);
+        self.tables.emit(&mut cx);
+        self.memories.emit(&mut cx);
+        self.globals.emit(&mut cx);
+        self.funcs.emit(&mut cx);
+        self.exports.emit(&mut cx);
         // TODO: start section
-        self.elements
-            .emit(&self.tables, &used, &mut module, indices);
+        self.elements.emit(&mut cx);
 
         module.sections_mut().sort_by_key(|s| match s {
             parity::Section::Type(_) => 1,
@@ -151,5 +148,10 @@ impl Module {
         let buffer =
             parity::serialize(module).context("failed to serialize wasm module to file")?;
         Ok(buffer)
+    }
+
+    /// Returns an iterator over all functions in this module
+    pub fn functions(&self) -> impl Iterator<Item = &Function> {
+        self.funcs.iter()
     }
 }

--- a/src/module/parse.rs
+++ b/src/module/parse.rs
@@ -1,0 +1,48 @@
+use crate::error::Result;
+use crate::module::elements::ElementId;
+use crate::module::functions::FunctionId;
+use crate::module::globals::GlobalId;
+use crate::module::memories::MemoryId;
+use crate::module::tables::TableId;
+use crate::ty::TypeId;
+use failure::bail;
+
+#[derive(Debug, Default)]
+pub struct IndicesToIds {
+    tables: Vec<TableId>,
+    types: Vec<TypeId>,
+    funcs: Vec<FunctionId>,
+    globals: Vec<GlobalId>,
+    memories: Vec<MemoryId>,
+    elements: Vec<ElementId>,
+}
+
+macro_rules! define_push_get {
+    ( $push:ident, $get:ident, $id_ty:ty, $member:ident ) => {
+        impl IndicesToIds {
+            /// Pushes a new local ID to map it to the next index internally
+            pub fn $push(&mut self, id: $id_ty) {
+                self.$member.push(id);
+            }
+
+            /// Gets the ID for a particular index
+            pub fn $get(&self, index: u32) -> Result<$id_ty> {
+                match self.$member.get(index as usize) {
+                    Some(x) => Ok(*x),
+                    None => bail!(
+                        "index `{}` is out of bounds for {}",
+                        index,
+                        stringify!($member)
+                    ),
+                }
+            }
+        }
+    };
+}
+
+define_push_get!(push_table, get_table, TableId, tables);
+define_push_get!(push_type, get_type, TypeId, types);
+define_push_get!(push_func, get_func, FunctionId, funcs);
+define_push_get!(push_global, get_global, GlobalId, globals);
+define_push_get!(push_memory, get_memory, MemoryId, memories);
+define_push_get!(push_element, get_element, ElementId, elements);

--- a/walrus-tests/tests/round_trip/import-func.wat
+++ b/walrus-tests/tests/round_trip/import-func.wat
@@ -1,0 +1,10 @@
+(module
+  (type (func))
+  (import "" "" (func (type 0)))
+  (export "b" (func 0))
+  )
+
+;; CHECK: (module
+;; NEXT:    (type (;0;) (func))
+;; NEXT:    (import "" "" (func (;0;) (type 0)))
+;; NEXT:    (export "b" (func 0)))

--- a/walrus-tests/tests/round_trip/import-gc.wat
+++ b/walrus-tests/tests/round_trip/import-gc.wat
@@ -1,0 +1,9 @@
+(module
+  (type (func))
+  (import "" "a" (func (type 0)))
+  (import "" "b" (table 1 anyfunc))
+  (import "" "c" (global i32))
+  (import "" "d" (memory 1))
+  )
+
+;; CHECK: (module)

--- a/walrus-tests/tests/round_trip/import-global.wat
+++ b/walrus-tests/tests/round_trip/import-global.wat
@@ -1,0 +1,8 @@
+(module
+  (import "" "" (global i32))
+  (export "b" (global 0))
+  )
+
+;; CHECK: (module
+;; NEXT:    (import "" "" (global (;0;) i32))
+;; NEXT:    (export "b" (global 0)))

--- a/walrus-tests/tests/round_trip/import-memory.wat
+++ b/walrus-tests/tests/round_trip/import-memory.wat
@@ -1,0 +1,9 @@
+(module
+  (import "" "" (memory 1))
+  (export "b" (memory 0))
+  )
+
+;; CHECK: (module
+;; NEXT:    (import "" "" (memory (;0;) 1))
+;; NEXT:    (export "b" (memory 0)))
+

--- a/walrus-tests/tests/round_trip/import-table.wat
+++ b/walrus-tests/tests/round_trip/import-table.wat
@@ -1,0 +1,8 @@
+(module
+  (import "" "" (table 1 anyfunc))
+  (export "b" (table 0))
+  )
+
+;; CHECK: (module
+;; NEXT:    (import "" "" (table (;0;) 1 anyfunc))
+;; NEXT:    (export "b" (table 0)))

--- a/walrus-tests/tests/round_trip/type-deduplicate.wat
+++ b/walrus-tests/tests/round_trip/type-deduplicate.wat
@@ -1,0 +1,16 @@
+(module
+  (type (;0;) (func))
+  (type (;1;) (func))
+  (func (;0;) (type 0))
+  (func (;1;) (type 1))
+
+  (export "a" (func 0))
+  (export "b" (func 1))
+  )
+
+;; CHECK: (module
+;; NEXT:    (type
+;; NEXT:    (func
+;; NEXT:    (func
+;; NEXT:    (export
+;; NEXT:    (export


### PR DESCRIPTION
This commit overhauls how imports are handled. The `Import` struct now
no longer contains structural information about imports but rather
contains ids pointing to an otherwise local instance. Each item, like
`Memory`, now locally indicates whether it's imported or not. For
example `Memory` has an `Option<ImportId>`, but `Global` has a
`GlobalKind::Import(id)` vs `GlobalKind::Local(const_value)`.

The goal here is to centralize as much as we can on types like
`Function`, `Global`, `Table`, etc. That way code handling them doesn't
have to worry about whether it's imported or defined, that's just a
minor local detail.

This involved quite a lot of refactoring internally, some notable points
being:

* All parsing functions now have access to the entire `Module` instead
  of trying to pass these around piecewise. This allows parsing imports
  to predefine globals, memories, functions, etc.

* Management of handling the mapping of index to id is now entirely
  local to the parsing phase. This information doesn't actually have any
  need to persist beyond parsing, and having it explicitly managed in
  separate state cleans up each `Module*` type a bit by having one less
  map to manage and fewer moving parts internally.

* Emission now also always has access to a `&Module`. Lots of parameters
  were popping up here so I threw them all into an `EmitContext` instead
  of passing them one-by-one. This may not be a great design though!

* Methods on `Module*` have become more consistent, and they should all
  follow the pattern of:

  * `get` - returns a reference to a type given its ID
  * `get_mut` - same as `get`, but mutable
  * `iter_mut` - iterates over all items of a type
  * `add_local` - adds a locally defined version of an item, taking all
    parameters of the item as arguments. Returns an ID
  * `add_import` - same as `add_local`, but takes an `ImportId` and
    possibly different arguments, adding an imported version.

The goal here was to hide the internal `arena` wherever possible and
avoid it leaking into public interfaces and/or exposing too many
implementation details.