### PR TITLE
Handle all remaining sections (except DWARF)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ failure = "0.1.2"
 id-arena = "2.0.1"
 parity-wasm = "0.35.6"
 petgraph = "0.4.13"
+log = "0.4"
 
 [dependencies.walrus-derive]
 path = "./walrus-derive"

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -4,6 +4,7 @@
 //! `parity_wasm::elements` types.
 
 use crate::ir::LocalId;
+use crate::module::data::DataId;
 use crate::module::elements::ElementId;
 use crate::module::functions::FunctionId;
 use crate::module::globals::GlobalId;
@@ -44,6 +45,7 @@ pub struct IdsToIndices {
     locals: HashMap<LocalId, u32>,
     memories: HashMap<MemoryId, u32>,
     elements: HashMap<ElementId, u32>,
+    data: HashMap<DataId, u32>,
 }
 
 macro_rules! define_get_push_index {
@@ -77,6 +79,7 @@ define_get_push_index!(get_func_index, push_func, FunctionId, funcs);
 define_get_push_index!(get_global_index, push_global, GlobalId, globals);
 define_get_push_index!(get_memory_index, push_memory, MemoryId, memories);
 define_get_push_index!(get_element_index, push_element, ElementId, elements);
+define_get_push_index!(get_data_index, push_data, DataId, data);
 
 impl IdsToIndices {
     /// Get the index for the given identifier.

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -26,12 +26,14 @@ pub type LocalId = Id<Local>;
 pub struct Local {
     id: LocalId,
     ty: ValType,
+    /// A human-readable name for this local, often useful when debugging
+    pub name: Option<String>,
 }
 
 impl Local {
     /// Construct a new local from the given id and type.
     pub fn new(id: LocalId, ty: ValType) -> Local {
-        Local { id, ty }
+        Local { id, ty, name: None }
     }
 
     /// Get this local's id that is unique across the whole module.

--- a/src/module/data.rs
+++ b/src/module/data.rs
@@ -20,8 +20,8 @@ pub struct Data {
     value: Vec<u8>,
 }
 
-/// All element segments of a wasm module, used to initialize `anyfunc` tables,
-/// used as function pointers.
+/// All passive data sections of a wasm module, used to initialize memories via
+/// various instructions.
 #[derive(Debug, Default)]
 pub struct ModuleData {
     arena: Arena<Data>,

--- a/src/module/data.rs
+++ b/src/module/data.rs
@@ -1,0 +1,126 @@
+//! Data segments within a wasm module.
+
+use crate::const_value::Const;
+use crate::emit::{Emit, EmitContext};
+use crate::error::Result;
+use crate::ir::Value;
+use crate::module::parse::IndicesToIds;
+use crate::module::Module;
+use crate::ty::ValType;
+use failure::{bail, ResultExt};
+use id_arena::{Arena, Id};
+use parity_wasm::elements;
+
+/// A passive element segment identifier
+pub type DataId = Id<Data>;
+
+/// A passive data segment
+#[derive(Debug)]
+pub struct Data {
+    value: Vec<u8>,
+}
+
+/// All element segments of a wasm module, used to initialize `anyfunc` tables,
+/// used as function pointers.
+#[derive(Debug, Default)]
+pub struct ModuleData {
+    arena: Arena<Data>,
+}
+
+impl ModuleData {
+    /// Get an element associated with an ID
+    pub fn get(&self, id: DataId) -> &Data {
+        &self.arena[id]
+    }
+
+    /// Get an element associated with an ID
+    pub fn get_mut(&mut self, id: DataId) -> &mut Data {
+        &mut self.arena[id]
+    }
+
+    /// Get a shared reference to this module's passive elements.
+    pub fn iter(&self) -> impl Iterator<Item = &Data> {
+        self.arena.iter().map(|(_, f)| f)
+    }
+}
+
+impl Module {
+    /// Parses a raw wasm section into a fully-formed `ModuleData` instance.
+    pub fn parse_data(
+        &mut self,
+        section: &elements::DataSection,
+        ids: &mut IndicesToIds,
+    ) -> Result<()> {
+        for (i, segment) in section.entries().iter().enumerate() {
+            if segment.passive() {
+                let id = self.data.arena.next_id();
+                self.data.arena.alloc(Data {
+                    value: segment.value().to_vec(),
+                });
+                ids.push_data(id);
+                continue;
+            }
+
+            let memory = ids.get_memory(segment.index())?;
+            let value = segment.value().to_vec();
+            let memory = self.memories.get_mut(memory);
+
+            let offset = segment.offset().as_ref().unwrap();
+            let offset = Const::eval(offset).with_context(|_e| format!("in segment {}", i))?;
+            match offset {
+                Const::Value(Value::I32(n)) => {
+                    memory.data.add_absolute(n as u32, value);
+                }
+                Const::Global(global) if self.globals.get(global).ty == ValType::I32 => {
+                    memory.data.add_relative(global, value);
+                }
+                _ => bail!("non-i32 constant in segment {}", i),
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Emit for ModuleData {
+    fn emit(&self, cx: &mut EmitContext) {
+        let mut segments = Vec::new();
+
+        // Sort table ids for a deterministic emission for now, eventually we
+        // may want some sort of sorting heuristic here.
+        let mut active = cx
+            .module
+            .memories
+            .iter()
+            .filter(|t| cx.used.memories.contains(&t.id()))
+            .map(|m| (m.id(), m))
+            .collect::<Vec<_>>();
+        active.sort_by_key(|pair| pair.0);
+
+        for (_memory_id, memory) in active {
+            segments.extend(memory.emit_data(cx.indices));
+        }
+
+        // After all the active segments are added add passive segments next. We
+        // may want to sort this more intelligently in the future. Othrewise
+        // emitting a segment here is in general much simpler than above as we
+        // know there are no holes.
+        for (id, segment) in self.arena.iter() {
+            if !cx.used.data.contains(&id) {
+                continue;
+            }
+            cx.indices.push_data(id);
+            segments.push(elements::DataSegment::new(
+                0,
+                None,
+                segment.value.clone(),
+                true,
+            ));
+        }
+
+        if segments.len() > 0 {
+            let elements = elements::DataSection::with_entries(segments);
+            let elements = elements::Section::Data(elements);
+            cx.dst.sections_mut().push(elements);
+        }
+    }
+}

--- a/src/module/parse.rs
+++ b/src/module/parse.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use crate::module::data::DataId;
 use crate::module::elements::ElementId;
 use crate::module::functions::FunctionId;
 use crate::module::globals::GlobalId;
@@ -15,6 +16,7 @@ pub struct IndicesToIds {
     globals: Vec<GlobalId>,
     memories: Vec<MemoryId>,
     elements: Vec<ElementId>,
+    data: Vec<DataId>,
 }
 
 macro_rules! define_push_get {
@@ -46,3 +48,4 @@ define_push_get!(push_func, get_func, FunctionId, funcs);
 define_push_get!(push_global, get_global, GlobalId, globals);
 define_push_get!(push_memory, get_memory, MemoryId, memories);
 define_push_get!(push_element, get_element, ElementId, elements);
+define_push_get!(push_data, get_data, DataId, data);

--- a/src/module/parse.rs
+++ b/src/module/parse.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use crate::ir::LocalId;
 use crate::module::data::DataId;
 use crate::module::elements::ElementId;
 use crate::module::functions::FunctionId;
@@ -7,6 +8,7 @@ use crate::module::memories::MemoryId;
 use crate::module::tables::TableId;
 use crate::ty::TypeId;
 use failure::bail;
+use std::collections::HashMap;
 
 #[derive(Debug, Default)]
 pub struct IndicesToIds {
@@ -17,6 +19,7 @@ pub struct IndicesToIds {
     memories: Vec<MemoryId>,
     elements: Vec<ElementId>,
     data: Vec<DataId>,
+    locals: HashMap<FunctionId, Vec<LocalId>>,
 }
 
 macro_rules! define_push_get {
@@ -49,3 +52,22 @@ define_push_get!(push_global, get_global, GlobalId, globals);
 define_push_get!(push_memory, get_memory, MemoryId, memories);
 define_push_get!(push_element, get_element, ElementId, elements);
 define_push_get!(push_data, get_data, DataId, data);
+
+impl IndicesToIds {
+    /// Pushes a new local ID to map it to the next index internally
+    pub fn push_local(&mut self, function: FunctionId, id: LocalId) {
+        self.locals.entry(function).or_insert(Vec::new()).push(id);
+    }
+
+    /// Gets the ID for a particular index
+    pub fn get_local(&self, function: FunctionId, index: u32) -> Result<LocalId> {
+        let ret = self
+            .locals
+            .get(&function)
+            .and_then(|list| list.get(index as usize));
+        match ret {
+            Some(x) => Ok(*x),
+            None => bail!("index `{}` is out of bounds for local", index,),
+        }
+    }
+}

--- a/src/module/producers.rs
+++ b/src/module/producers.rs
@@ -1,0 +1,93 @@
+//! Handling of the wasm `producers` section
+//!
+//! Specified upstream at
+//! https://github.com/WebAssembly/tool-conventions/blob/master/ProducersSection.md
+
+use crate::error::Result;
+use failure::bail;
+use parity_wasm::elements::*;
+use std::collections::HashMap;
+
+/// Representation of the wasm custom section `producers`
+#[derive(Debug, Default)]
+pub struct ModuleProducers {
+    fields: HashMap<String, HashMap<String, String>>,
+}
+
+impl ModuleProducers {
+    /// Parse a producers section from the custom section payload specified.
+    pub fn parse(mut data: &[u8]) -> Result<ModuleProducers> {
+        let mut ret = ModuleProducers::default();
+        let amt: u32 = VarUint32::deserialize(&mut data)?.into();
+
+        for _ in 0..amt {
+            let name = String::deserialize(&mut data)?;
+            let cnt: u32 = VarUint32::deserialize(&mut data)?.into();
+
+            let map = ret.fields.entry(name).or_insert(HashMap::new());
+            for _ in 0..cnt {
+                let name = String::deserialize(&mut data)?;
+                let version = String::deserialize(&mut data)?;
+                map.insert(name, version);
+            }
+        }
+        if data.len() != 0 {
+            bail!("failed to decode all data in producers section");
+        }
+
+        Ok(ret)
+    }
+
+    /// Serialize this producers section into its binary format
+    pub fn emit(&self) -> Vec<u8> {
+        // re-serialize these fields back into the custom section
+        let mut dst = Vec::new();
+        VarUint32::from(self.fields.len() as u32)
+            .serialize(&mut dst)
+            .unwrap();
+
+        // emit in a deterministic order, so be sure to sort
+        let mut fields = self.fields.iter().collect::<Vec<_>>();
+        fields.sort_by_key(|f| f.0);
+
+        for (field, values) in fields {
+            field.clone().serialize(&mut dst).unwrap();
+            VarUint32::from(values.len() as u32)
+                .serialize(&mut dst)
+                .unwrap();
+
+            // also be sure to emit the values in a deterministic order
+            let mut values = values.iter().collect::<Vec<_>>();
+            values.sort();
+
+            for (name, version) in values {
+                name.clone().serialize(&mut dst).unwrap();
+                version.clone().serialize(&mut dst).unwrap();
+            }
+        }
+
+        dst
+    }
+
+    /// Adds a new `language` (versioned) to the producers section
+    pub fn add_language(&mut self, language: &str, version: &str) {
+        self.field("language", language, version);
+    }
+
+    /// Adds a new `processed-by` (versioned) to the producers section
+    pub fn add_processed_by(&mut self, tool: &str, version: &str) {
+        self.field("processed-by", tool, version);
+    }
+
+    /// Adds a new `sdk` (versioned) to the producers section
+    pub fn add_sdk(&mut self, sdk: &str, version: &str) {
+        self.field("sdk", sdk, version);
+    }
+
+    fn field(&mut self, field: &str, name: &str, version: &str) {
+        self.fields
+            .entry(field.to_string())
+            .or_insert(HashMap::new())
+            .insert(name.to_string(), version.to_string());
+    }
+}

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -1,4 +1,5 @@
 use crate::ir::*;
+use crate::module::data::DataId;
 use crate::module::elements::ElementId;
 use crate::module::exports::{ExportId, ExportItem};
 use crate::module::functions::{FunctionId, FunctionKind, LocalFunction};
@@ -26,8 +27,10 @@ pub struct Used {
     pub globals: HashSet<GlobalId>,
     /// The module's used memories.
     pub memories: HashSet<MemoryId>,
-    /// The module's used passive segments.
+    /// The module's used passive element segments.
     pub elements: HashSet<ElementId>,
+    /// The module's used passive data segments.
+    pub data: HashSet<DataId>,
 }
 
 impl Used {

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -8,7 +8,7 @@ use crate::module::memories::MemoryId;
 use crate::module::tables::{TableId, TableKind};
 use crate::module::Module;
 use crate::ty::TypeId;
-use std::collections::{HashSet, HashMap};
+use std::collections::{HashMap, HashSet};
 
 /// Finds the things within a module that are used.
 ///
@@ -157,7 +157,10 @@ impl<'expr> Visitor<'expr> for UsedVisitor<'expr, '_> {
     }
 
     fn visit_local_id(&mut self, &l: &LocalId) {
-        self.stack.used.locals.entry(self.id)
+        self.stack
+            .used
+            .locals
+            .entry(self.id)
             .or_insert(HashSet::new())
             .insert(l);
     }

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -55,6 +55,9 @@ impl Used {
                 }
             }
         }
+        if let Some(f) = module.start {
+            stack.push_func(f);
+        }
 
         while stack.functions.len() > 0 || stack.tables.len() > 0 {
             while let Some(f) = stack.functions.pop() {

--- a/walrus-tests-utils/src/lib.rs
+++ b/walrus-tests-utils/src/lib.rs
@@ -29,7 +29,10 @@ pub fn wat2wasm(path: &Path) -> Vec<u8> {
     wasm.set_extension("wasm");
 
     let mut cmd = Command::new("wat2wasm");
-    cmd.arg(path).arg("-o").arg(file.path());
+    cmd.arg(path)
+        .arg("--debug-names")
+        .arg("-o")
+        .arg(file.path());
     println!("running: {:?}", cmd);
     let output = cmd.output().expect("should spawn wat2wasm OK");
 
@@ -66,7 +69,11 @@ pub fn wasm2wat(path: &Path) -> String {
     cmd.arg(path);
     println!("running: {:?}", cmd);
     let output = cmd.output().expect("should spawn wasm2wat OK");
-    assert!(output.status.success(), "should run wasm2wat OK");
+    if !output.status.success() {
+        println!("status: {}", output.status);
+        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        panic!("expected ok");
+    }
     String::from_utf8_lossy(&output.stdout).into_owned()
 }
 

--- a/walrus-tests/tests/round_trip/block.wat
+++ b/walrus-tests/tests/round_trip/block.wat
@@ -12,7 +12,7 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      i32.const 0
 ;; NEXT:      drop
 ;; NEXT:      block  ;; label = @1
@@ -20,4 +20,4 @@
 ;; NEXT:        drop
 ;; NEXT:      end
 ;; NEXT:      i32.const 2)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/br_table.wat
+++ b/walrus-tests/tests/round_trip/br_table.wat
@@ -18,7 +18,7 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
+;; NEXT:    (func $f (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32)
 ;; NEXT:      block  ;; label = @1
 ;; NEXT:        block  ;; label = @2
@@ -33,4 +33,4 @@
 ;; NEXT:        return
 ;; NEXT:      end
 ;; NEXT:      i32.const 100)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/br_table.wat
+++ b/walrus-tests/tests/round_trip/br_table.wat
@@ -19,7 +19,6 @@
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (func $f (type 0) (param i32) (result i32)
-;; NEXT:      (local i32)
 ;; NEXT:      block  ;; label = @1
 ;; NEXT:        block  ;; label = @2
 ;; NEXT:          block  ;; label = @3

--- a/walrus-tests/tests/round_trip/call.wat
+++ b/walrus-tests/tests/round_trip/call.wat
@@ -1,14 +1,14 @@
 (module
   (type (;0;) (func (result i32)))
-  (import "env" "f" (func $f (type 0)))
+  (import "env" "f" (func (;0;) (type 0)))
   (func $g (type 0) (result i32)
-    (call $f))
+    (call 0))
   (export "g" (func $g)))
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
 ;; NEXT:    (import "env" "f" (func (;0;) (type 0)))
-;; NEXT:    (func (;1;) (type 0) (result i32)
+;; NEXT:    (func $g (type 0) (result i32)
 ;; NEXT:      call 0)
-;; NEXT:    (export "g" (func 1)))
+;; NEXT:    (export "g" (func $g)))
 

--- a/walrus-tests/tests/round_trip/call_2.wat
+++ b/walrus-tests/tests/round_trip/call_2.wat
@@ -2,17 +2,17 @@
 
 (module
   (type (;0;) (func (param i32) (result i32)))
-  (import "env" "f" (func $f (type 0)))
+  (import "env" "f" (func (type 0)))
   (func $g (type 0) (param i32) (result i32)
     (local.get 0)
-    (call $f))
+    (call 0))
   (export "g" (func $g)))
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (import "env" "f" (func (;0;) (type 0)))
-;; NEXT:    (func (;1;) (type 0) (param i32) (result i32)
+;; NEXT:    (func $g (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32)
 ;; NEXT:      local.get 0
 ;; NEXT:      call 0)
-;; NEXT:    (export "g" (func 1)))
+;; NEXT:    (export "g" (func $g)))

--- a/walrus-tests/tests/round_trip/call_2.wat
+++ b/walrus-tests/tests/round_trip/call_2.wat
@@ -12,7 +12,6 @@
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (import "env" "f" (func (;0;) (type 0)))
 ;; NEXT:    (func $g (type 0) (param i32) (result i32)
-;; NEXT:      (local i32)
 ;; NEXT:      local.get 0
 ;; NEXT:      call 0)
 ;; NEXT:    (export "g" (func $g)))

--- a/walrus-tests/tests/round_trip/const.wat
+++ b/walrus-tests/tests/round_trip/const.wat
@@ -6,6 +6,6 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/count-to-ten.wat
+++ b/walrus-tests/tests/round_trip/count-to-ten.wat
@@ -11,7 +11,7 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      (local i32)
 ;; NEXT:      i32.const 9
 ;; NEXT:      local.set 0
@@ -25,4 +25,4 @@
 ;; NEXT:        local.set 0
 ;; NEXT:      end
 ;; NEXT:      i32.const 10)
-;; NEXT:    (export "count_to_ten" (func 0)))
+;; NEXT:    (export "count_to_ten" (func $f)))

--- a/walrus-tests/tests/round_trip/drop.wat
+++ b/walrus-tests/tests/round_trip/drop.wat
@@ -6,7 +6,7 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func))
-;; NEXT:    (func (;0;) (type 0)
+;; NEXT:    (func $f (type 0)
 ;; NEXT:      i32.const 42
 ;; NEXT:      drop)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/fac.wat
+++ b/walrus-tests/tests/round_trip/fac.wat
@@ -31,23 +31,23 @@
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (func $fac (type 0) (param i32) (result i32)
-;; NEXT:      (local i32 i32)
+;; NEXT:      (local i32)
 ;; NEXT:      block  ;; label = @1
-;; NEXT:        local.get 1
-;; NEXT:        local.set 0
+;; NEXT:        local.get 0
+;; NEXT:        local.set 1
 ;; NEXT:        loop  ;; label = @2
-;; NEXT:          local.get 1
+;; NEXT:          local.get 0
 ;; NEXT:          i32.eqz
 ;; NEXT:          br_if 1 (;@1;)
+;; NEXT:          local.get 1
 ;; NEXT:          local.get 0
-;; NEXT:          local.get 1
 ;; NEXT:          i32.mul
-;; NEXT:          local.set 0
-;; NEXT:          local.get 1
+;; NEXT:          local.set 1
+;; NEXT:          local.get 0
 ;; NEXT:          i32.const 1
 ;; NEXT:          i32.sub
-;; NEXT:          local.set 1
+;; NEXT:          local.set 0
 ;; NEXT:        end
 ;; NEXT:      end
-;; NEXT:      local.get 0)
+;; NEXT:      local.get 1)
 ;; NEXT:    (export "fac" (func $fac)))

--- a/walrus-tests/tests/round_trip/fac.wat
+++ b/walrus-tests/tests/round_trip/fac.wat
@@ -30,7 +30,7 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
+;; NEXT:    (func $fac (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32 i32)
 ;; NEXT:      block  ;; label = @1
 ;; NEXT:        local.get 1
@@ -50,4 +50,4 @@
 ;; NEXT:        end
 ;; NEXT:      end
 ;; NEXT:      local.get 0)
-;; NEXT:    (export "fac" (func 0)))
+;; NEXT:    (export "fac" (func $fac)))

--- a/walrus-tests/tests/round_trip/gc_keep_used_funcs.wat
+++ b/walrus-tests/tests/round_trip/gc_keep_used_funcs.wat
@@ -10,11 +10,11 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      i32.const 42
 ;; NEXT:      i32.const 1
 ;; NEXT:      i32.add)
-;; NEXT:    (func (;1;) (type 0) (result i32)
-;; NEXT:      call 0)
-;; NEXT:    (export "g" (func 1)))
+;; NEXT:    (func $g (type 0) (result i32)
+;; NEXT:      call $f)
+;; NEXT:    (export "g" (func $g)))
 

--- a/walrus-tests/tests/round_trip/gc_keep_used_imports.wat
+++ b/walrus-tests/tests/round_trip/gc_keep_used_imports.wat
@@ -7,5 +7,5 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (import "env" "used" (func (;0;) (type 0)))
-;; NEXT:    (export "used" (func 0)))
+;; NEXT:    (import "env" "used" (func $used (type 0)))
+;; NEXT:    (export "used" (func $used)))

--- a/walrus-tests/tests/round_trip/gc_unused_funcs.wat
+++ b/walrus-tests/tests/round_trip/gc_unused_funcs.wat
@@ -10,6 +10,6 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/gc_unused_funcs_2.wat
+++ b/walrus-tests/tests/round_trip/gc_unused_funcs_2.wat
@@ -16,6 +16,6 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/gc_unused_global.wat
+++ b/walrus-tests/tests/round_trip/gc_unused_global.wat
@@ -9,6 +9,6 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/gc_unused_imports.wat
+++ b/walrus-tests/tests/round_trip/gc_unused_imports.wat
@@ -9,6 +9,6 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/gc_unused_memories.wat
+++ b/walrus-tests/tests/round_trip/gc_unused_memories.wat
@@ -9,6 +9,6 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/gc_unused_tables.wat
+++ b/walrus-tests/tests/round_trip/gc_unused_tables.wat
@@ -9,6 +9,6 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/gc_unused_types.wat
+++ b/walrus-tests/tests/round_trip/gc_unused_types.wat
@@ -9,6 +9,6 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/if_else.wat
+++ b/walrus-tests/tests/round_trip/if_else.wat
@@ -11,7 +11,7 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
+;; NEXT:    (func $if_else (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32)
 ;; NEXT:      local.get 0
 ;; NEXT:      if (result i32)  ;; label = @1
@@ -19,4 +19,4 @@
 ;; NEXT:      else
 ;; NEXT:        i32.const 2
 ;; NEXT:      end)
-;; NEXT:    (export "if_else" (func 0)))
+;; NEXT:    (export "if_else" (func $if_else)))

--- a/walrus-tests/tests/round_trip/if_else.wat
+++ b/walrus-tests/tests/round_trip/if_else.wat
@@ -12,7 +12,6 @@
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (func $if_else (type 0) (param i32) (result i32)
-;; NEXT:      (local i32)
 ;; NEXT:      local.get 0
 ;; NEXT:      if (result i32)  ;; label = @1
 ;; NEXT:        i32.const 1

--- a/walrus-tests/tests/round_trip/if_else_2.wat
+++ b/walrus-tests/tests/round_trip/if_else_2.wat
@@ -16,7 +16,6 @@
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (func $if_else (type 0) (param i32) (result i32)
-;; NEXT:      (local i32)
 ;; NEXT:      local.get 0
 ;; NEXT:      if (result i32)  ;; label = @1
 ;; NEXT:        i32.const 2

--- a/walrus-tests/tests/round_trip/if_else_2.wat
+++ b/walrus-tests/tests/round_trip/if_else_2.wat
@@ -15,7 +15,7 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
+;; NEXT:    (func $if_else (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32)
 ;; NEXT:      local.get 0
 ;; NEXT:      if (result i32)  ;; label = @1
@@ -27,4 +27,4 @@
 ;; NEXT:        local.set 0
 ;; NEXT:        i32.const 2
 ;; NEXT:      end)
-;; NEXT:    (export "if_else" (func 0)))
+;; NEXT:    (export "if_else" (func $if_else)))

--- a/walrus-tests/tests/round_trip/inc.wat
+++ b/walrus-tests/tests/round_trip/inc.wat
@@ -9,7 +9,6 @@
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (func $inc (type 0) (param i32) (result i32)
-;; NEXT:      (local i32)
 ;; NEXT:      local.get 0
 ;; NEXT:      i32.const 1
 ;; NEXT:      i32.add)

--- a/walrus-tests/tests/round_trip/inc.wat
+++ b/walrus-tests/tests/round_trip/inc.wat
@@ -8,9 +8,9 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
+;; NEXT:    (func $inc (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32)
 ;; NEXT:      local.get 0
 ;; NEXT:      i32.const 1
 ;; NEXT:      i32.add)
-;; NEXT:    (export "inc" (func 0)))
+;; NEXT:    (export "inc" (func $inc)))

--- a/walrus-tests/tests/round_trip/loop.wat
+++ b/walrus-tests/tests/round_trip/loop.wat
@@ -7,7 +7,7 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func))
-;; NEXT:    (func (;0;) (type 0)
+;; NEXT:    (func $f (type 0)
 ;; NEXT:      loop  ;; label = @1
 ;; NEXT:      end)
-;; NEXT:    (export "inf_loop" (func 0)))
+;; NEXT:    (export "inf_loop" (func $f)))

--- a/walrus-tests/tests/round_trip/many_funcs.wat
+++ b/walrus-tests/tests/round_trip/many_funcs.wat
@@ -21,7 +21,7 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $d (type 0) (result i32)
 ;; NEXT:      i32.const 0
 ;; NEXT:      i32.const 1
 ;; NEXT:      i32.add
@@ -29,20 +29,20 @@
 ;; NEXT:      i32.const 3
 ;; NEXT:      i32.add
 ;; NEXT:      i32.add)
-;; NEXT:    (func (;1;) (type 0) (result i32)
+;; NEXT:    (func $c (type 0) (result i32)
 ;; NEXT:      i32.const 3
 ;; NEXT:      i32.const 4
 ;; NEXT:      i32.const 5
 ;; NEXT:      i32.add
 ;; NEXT:      i32.add)
-;; NEXT:    (func (;2;) (type 0) (result i32)
+;; NEXT:    (func $b (type 0) (result i32)
 ;; NEXT:      i32.const 1
 ;; NEXT:      i32.const 2
 ;; NEXT:      i32.add)
-;; NEXT:    (func (;3;) (type 0) (result i32)
+;; NEXT:    (func $a (type 0) (result i32)
 ;; NEXT:      i32.const 0)
-;; NEXT:    (export "a" (func 3))
-;; NEXT:    (export "b" (func 2))
-;; NEXT:    (export "c" (func 1))
-;; NEXT:    (export "d" (func 0)))
+;; NEXT:    (export "a" (func $a))
+;; NEXT:    (export "b" (func $b))
+;; NEXT:    (export "c" (func $c))
+;; NEXT:    (export "d" (func $d)))
 

--- a/walrus-tests/tests/round_trip/name-section.wat
+++ b/walrus-tests/tests/round_trip/name-section.wat
@@ -1,0 +1,5 @@
+(module
+  (func $wat)
+  (export "another" (func $wat)))
+
+;; CHECK: (func $wat

--- a/walrus-tests/tests/round_trip/params.wat
+++ b/walrus-tests/tests/round_trip/params.wat
@@ -1,0 +1,11 @@
+(module
+  (func (param i32 i32) (result i32)
+    local.get 1
+    local.get 0
+    i32.add)
+  (export "foo" (func 0)))
+
+;; CHECK: (func (;0;) (type 0) (param i32 i32) (result i32)
+;; NEXT:    local.get 1
+;; NEXT:    local.get 0
+;; NEXT:    i32.add)

--- a/walrus-tests/tests/round_trip/return.wat
+++ b/walrus-tests/tests/round_trip/return.wat
@@ -3,6 +3,6 @@
     (return (i32.const 1)))
   (export "f" (func $f)))
 
-;; CHECK: (func (;0;) (type 0) (result i32)
+;; CHECK: (func $f (type 0) (result i32)
 ;; NEXT:    i32.const 1
 ;; NEXT:    return)

--- a/walrus-tests/tests/round_trip/return_2.wat
+++ b/walrus-tests/tests/round_trip/return_2.wat
@@ -4,6 +4,6 @@
     i32.const 2)
   (export "f" (func $f)))
 
-;; CHECK: (func (;0;) (type 0) (result i32)
+;; CHECK: (func $f (type 0) (result i32)
 ;; NEXT:    i32.const 1
 ;; NEXT:    return)

--- a/walrus-tests/tests/round_trip/select.wat
+++ b/walrus-tests/tests/round_trip/select.wat
@@ -10,7 +10,6 @@
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
 ;; NEXT:    (func $do_select (type 0) (param i32) (result i32)
-;; NEXT:      (local i32)
 ;; NEXT:      i32.const 1
 ;; NEXT:      i32.const 2
 ;; NEXT:      local.get 0

--- a/walrus-tests/tests/round_trip/select.wat
+++ b/walrus-tests/tests/round_trip/select.wat
@@ -9,10 +9,10 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func (;0;) (type 0) (param i32) (result i32)
+;; NEXT:    (func $do_select (type 0) (param i32) (result i32)
 ;; NEXT:      (local i32)
 ;; NEXT:      i32.const 1
 ;; NEXT:      i32.const 2
 ;; NEXT:      local.get 0
 ;; NEXT:      select)
-;; NEXT:    (export "do_select" (func 0)))
+;; NEXT:    (export "do_select" (func $do_select)))

--- a/walrus-tests/tests/round_trip/start.wat
+++ b/walrus-tests/tests/round_trip/start.wat
@@ -1,0 +1,7 @@
+(module
+  (start 0)
+  (func))
+
+;; CHECK: (module
+;; NEXT     (start 0)
+;; NEXT     (func))

--- a/walrus-tests/tests/round_trip/stuff-after-loop-2.wat
+++ b/walrus-tests/tests/round_trip/stuff-after-loop-2.wat
@@ -9,9 +9,9 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      loop  ;; label = @1
 ;; NEXT:        br 0 (;@1;)
 ;; NEXT:      end
 ;; NEXT:      i32.const 1)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/stuff-after-loop.wat
+++ b/walrus-tests/tests/round_trip/stuff-after-loop.wat
@@ -8,8 +8,8 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      loop  ;; label = @1
 ;; NEXT:      end
 ;; NEXT:      i32.const 1)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/type-deduplicate.wat
+++ b/walrus-tests/tests/round_trip/type-deduplicate.wat
@@ -1,10 +1,10 @@
 (module
   (type (;0;) (func))
   (type (;1;) (func))
-  (func (;0;) (type 0))
+  (func $f (type 0))
   (func (;1;) (type 1))
 
-  (export "a" (func 0))
+  (export "a" (func $f))
   (export "b" (func 1))
   )
 

--- a/walrus-tests/tests/round_trip/unreachable.wat
+++ b/walrus-tests/tests/round_trip/unreachable.wat
@@ -6,6 +6,6 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      unreachable)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/unreachable_2.wat
+++ b/walrus-tests/tests/round_trip/unreachable_2.wat
@@ -7,6 +7,6 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      unreachable)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/unreachable_3.wat
+++ b/walrus-tests/tests/round_trip/unreachable_3.wat
@@ -12,9 +12,9 @@
 
 ;; CHECK: (module
 ;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func (;0;) (type 0) (result i32)
+;; NEXT:    (func $f (type 0) (result i32)
 ;; NEXT:      block  ;; label = @1
 ;; NEXT:        unreachable
 ;; NEXT:      end
 ;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func 0)))
+;; NEXT:    (export "f" (func $f)))

--- a/walrus-tests/tests/round_trip/unreachable_4.wat
+++ b/walrus-tests/tests/round_trip/unreachable_4.wat
@@ -4,5 +4,5 @@
     i32.add)
   (export "f" (func $f)))
 
-;; CHECK: (func (;0;) (type 0) (result i32)
+;; CHECK: (func $f (type 0) (result i32)
 ;; NEXT:    unreachable)

--- a/walrus-tests/tests/round_trip/used-local-in-local.wat
+++ b/walrus-tests/tests/round_trip/used-local-in-local.wat
@@ -4,10 +4,10 @@
     (local i32 i32)
     local.get 0
     local.set 1)
-  (export "foo" (func 0))
+  (export "foo" (func $foo))
   )
 
-;; CHECK: (func
+;; CHECK: (func $foo
 ;; NEXT:    (local i32 i32)
 ;; NEXT:    local.get 1
 ;; NEXT:    local.set 0)

--- a/walrus-tests/tests/round_trip/used-local-set.wat
+++ b/walrus-tests/tests/round_trip/used-local-set.wat
@@ -3,10 +3,10 @@
   (func $foo (local i32)
     global.get 0
     local.set 0)
-  (export "foo" (func 0))
+  (export "foo" (func $foo))
   )
 
-;; CHECK: (func (;0;) (type 0)
+;; CHECK: (func $foo (type 0)
 ;; NEXT:    (local i32)
 ;; NEXT:    global.get 0
 ;; NEXT:    local.set 0)


### PR DESCRIPTION
This commit hooks up handling of all remaining sections (except DWARF debug info ones)

* The `start` section
* First-class treatment of the data section
* The wasm names section (function, module, and local names)
* Some miscellaneus ones  parity-wasm otherwise parses