### PR TITLE
Add support for memory instructions

### DIFF
--- a/walrus-tests/tests/ir/mem.wat
+++ b/walrus-tests/tests/ir/mem.wat
@@ -1,0 +1,17 @@
+(module
+  (memory 0)
+  (func
+    i32.const 1
+    i32.load
+    drop
+
+    i32.const 2
+    f32.const 3
+    f32.store))
+
+;; CHECK: (load 0
+;; NEXT:    (const 1)
+
+;; CHECK: (store 0
+;; NEXT     (const 2)
+;; NEXT     (const 3)


### PR DESCRIPTION
Curious on thoughts for the `LoadKind` and `StoreKind` enums, I'm not sure if those are the most useful or best designed here.