### PR TITLE
Define a walrus-specific hasher for hash maps

### DIFF
--- a/src/emit.rs
+++ b/src/emit.rs
@@ -3,17 +3,17 @@
 //! raw wasm structure's index spaces.
 
 use crate::encode::{Encoder, MAX_U32_LENGTH};
-use crate::ir::LocalId;
-use crate::module::data::DataId;
-use crate::module::elements::ElementId;
-use crate::module::functions::FunctionId;
-use crate::module::globals::GlobalId;
-use crate::module::memories::MemoryId;
-use crate::module::tables::TableId;
+use crate::ir::Local;
+use crate::map::IdHashMap;
+use crate::module::data::{Data, DataId};
+use crate::module::elements::{Element, ElementId};
+use crate::module::functions::{Function, FunctionId};
+use crate::module::globals::{Global, GlobalId};
+use crate::module::memories::{Memory, MemoryId};
+use crate::module::tables::{Table, TableId};
 use crate::module::Module;
 use crate::passes::Used;
-use crate::ty::TypeId;
-use std::collections::HashMap;
+use crate::ty::{Type, TypeId};
 use std::ops::{Deref, DerefMut};
 
 pub struct EmitContext<'a> {
@@ -49,14 +49,14 @@ impl<'a, T: ?Sized + Emit> Emit for &'a T {
 /// since the identifier `A` doesn't exist at the raw wasm level.
 #[derive(Debug, Default)]
 pub struct IdsToIndices {
-    tables: HashMap<TableId, u32>,
-    types: HashMap<TypeId, u32>,
-    funcs: HashMap<FunctionId, u32>,
-    globals: HashMap<GlobalId, u32>,
-    memories: HashMap<MemoryId, u32>,
-    elements: HashMap<ElementId, u32>,
-    data: HashMap<DataId, u32>,
-    pub locals: HashMap<FunctionId, HashMap<LocalId, u32>>,
+    tables: IdHashMap<Table, u32>,
+    types: IdHashMap<Type, u32>,
+    funcs: IdHashMap<Function, u32>,
+    globals: IdHashMap<Global, u32>,
+    memories: IdHashMap<Memory, u32>,
+    elements: IdHashMap<Element, u32>,
+    data: IdHashMap<Data, u32>,
+    pub locals: IdHashMap<Function, IdHashMap<Local, u32>>,
 }
 
 macro_rules! define_get_push_index {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod emit;
 mod encode;
 pub mod error;
 pub mod ir;
+mod map;
 pub mod module;
 mod parse;
 pub mod passes;

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,0 +1,59 @@
+//! Walrus-specific hash maps and hash sets which typically hash much more
+//! quickly than libstd's hash map which isn't optimized for speed.
+
+use id_arena::Id;
+use std::collections::{HashMap, HashSet};
+use std::hash::{BuildHasher, Hasher};
+
+/// Type parameter for the hasher of a `HashMap` or `HashSet`
+#[derive(Default, Copy, Clone, Debug)]
+pub struct BuildIdHasher;
+
+/// Hasher constructed by `BuildIdHasher`, only ever used to hash an `Id`
+#[derive(Default, Copy, Clone, Debug)]
+pub struct IdHasher {
+    hash: u64,
+}
+
+pub type IdHashMap<K, V> = HashMap<Id<K>, V, BuildIdHasher>;
+pub type IdHashSet<T> = HashSet<Id<T>, BuildIdHasher>;
+
+impl BuildHasher for BuildIdHasher {
+    type Hasher = IdHasher;
+
+    fn build_hasher(&self) -> IdHasher {
+        IdHasher { hash: 0 }
+    }
+}
+
+// This is the "speed" of this hasher. We're only ever going to hash `Id<T>`,
+// and `Id<T>` is composed of two parts: one part arena ID and one part index
+// in the arena. The arena ID is a 32-bit integer and the index is a `usize`, so
+// we're only going to handle those two types here.
+//
+// The goal is to produce a 64-bit result, and 32 of those comes from the arena
+// ID. We can assume that none of the arena indexes are larger than 32-bit
+// because wasm can't encode more than 2^32 items anyway, so we can basically
+// just shift each item into the lower 32-bits of the hash. Ideally this'll end
+// up producing a very optimized version of hashing!
+//
+// To explore this a bit, see https://godbolt.org/z/QxkXgF
+impl Hasher for IdHasher {
+    fn write_u32(&mut self, amt: u32) {
+        self.hash <<= 32;
+        self.hash |= amt as u64;
+    }
+
+    fn write_usize(&mut self, amt: usize) {
+        self.hash <<= 32;
+        self.hash |= amt as u64;
+    }
+
+    fn write(&mut self, _other: &[u8]) {
+        panic!("hashing an `Id` should only be usize/u32")
+    }
+
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+}

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -1,14 +1,14 @@
 use crate::emit::IdsToIndices;
 use crate::encode::Encoder;
 use crate::ir::*;
+use crate::map::IdHashMap;
 use crate::module::functions::LocalFunction;
 use crate::ty::ValType;
-use std::collections::HashMap;
 
 pub(crate) fn run(
     func: &LocalFunction,
     indices: &IdsToIndices,
-    local_indices: &HashMap<LocalId, u32>,
+    local_indices: &IdHashMap<Local, u32>,
     encoder: &mut Encoder,
 ) {
     let mut v = Emit {
@@ -31,7 +31,7 @@ struct Emit<'a, 'b> {
 
     // Needed so we can map locals to their indices.
     indices: &'a IdsToIndices,
-    local_indices: &'a HashMap<LocalId, u32>,
+    local_indices: &'a IdHashMap<Local, u32>,
 
     // Stack of blocks that we are currently emitting instructions for. A branch
     // is only valid if its target is one of these blocks.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,14 +1,14 @@
 use crate::error::Result;
 use crate::ir::LocalId;
+use crate::map::IdHashMap;
 use crate::module::data::DataId;
 use crate::module::elements::ElementId;
-use crate::module::functions::FunctionId;
+use crate::module::functions::{Function, FunctionId};
 use crate::module::globals::GlobalId;
 use crate::module::memories::MemoryId;
 use crate::module::tables::TableId;
 use crate::ty::TypeId;
 use failure::bail;
-use std::collections::HashMap;
 
 #[derive(Debug, Default)]
 pub struct IndicesToIds {
@@ -19,7 +19,7 @@ pub struct IndicesToIds {
     memories: Vec<MemoryId>,
     elements: Vec<ElementId>,
     data: Vec<DataId>,
-    locals: HashMap<FunctionId, Vec<LocalId>>,
+    locals: IdHashMap<Function, Vec<LocalId>>,
 }
 
 macro_rules! define_push_get {

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -1,15 +1,15 @@
 use crate::const_value::Const;
 use crate::ir::*;
-use crate::module::data::DataId;
-use crate::module::elements::ElementId;
+use crate::map::{IdHashMap, IdHashSet};
+use crate::module::data::Data;
+use crate::module::elements::Element;
 use crate::module::exports::{ExportId, ExportItem};
-use crate::module::functions::{FunctionId, FunctionKind, LocalFunction};
-use crate::module::globals::{GlobalId, GlobalKind};
-use crate::module::memories::MemoryId;
-use crate::module::tables::{TableId, TableKind};
+use crate::module::functions::{Function, FunctionId, FunctionKind, LocalFunction};
+use crate::module::globals::{Global, GlobalId, GlobalKind};
+use crate::module::memories::{Memory, MemoryId};
+use crate::module::tables::{Table, TableId, TableKind};
 use crate::module::Module;
-use crate::ty::TypeId;
-use std::collections::{HashMap, HashSet};
+use crate::ty::{Type, TypeId};
 
 /// Finds the things within a module that are used.
 ///
@@ -19,21 +19,21 @@ use std::collections::{HashMap, HashSet};
 #[derive(Debug, Default)]
 pub struct Used {
     /// The module's used tables.
-    pub tables: HashSet<TableId>,
+    pub tables: IdHashSet<Table>,
     /// The module's used types.
-    pub types: HashSet<TypeId>,
+    pub types: IdHashSet<Type>,
     /// The module's used functions.
-    pub funcs: HashSet<FunctionId>,
+    pub funcs: IdHashSet<Function>,
     /// The module's used globals.
-    pub globals: HashSet<GlobalId>,
+    pub globals: IdHashSet<Global>,
     /// The module's used memories.
-    pub memories: HashSet<MemoryId>,
+    pub memories: IdHashSet<Memory>,
     /// The module's used passive element segments.
-    pub elements: HashSet<ElementId>,
+    pub elements: IdHashSet<Element>,
     /// The module's used passive data segments.
-    pub data: HashSet<DataId>,
+    pub data: IdHashSet<Data>,
     /// Locals used within functions
-    pub locals: HashMap<FunctionId, HashSet<LocalId>>,
+    pub locals: IdHashMap<Function, IdHashSet<Local>>,
 }
 
 impl Used {
@@ -195,7 +195,7 @@ impl<'expr> Visitor<'expr> for UsedVisitor<'expr, '_> {
             .used
             .locals
             .entry(self.id)
-            .or_insert(HashSet::new())
+            .or_insert_with(IdHashSet::default)
             .insert(l);
     }
 }


### PR DESCRIPTION
One of the hottest parts of profiling `examples/round-trip.rs` on
`clang.wasm` is hashing, presumably with lots of lookups and stores. The
standard library hashing is known to not be optimized for speed by
default, but that's for DoS protection that we're not too concerned
about here.

Instead this commit defines a custom hasher specifically designed to
quickly hash `Id<T>` from the `id-arena` crate. Overally this improves
the runtime of `round-trip` on `clang.wasm` by 15%, reducing the runtime
from 1.9s to 1.6s.