### PR TITLE
Implement support for all atomic instructions

### DIFF
--- a/walrus-tests-utils/src/lib.rs
+++ b/walrus-tests-utils/src/lib.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Once, ONCE_INIT};
 
+pub const FEATURES: &[&str] = &["--enable-threads"];
+
 fn require_wat2wasm() {
     let status = Command::new("wat2wasm")
         .arg("--help")
@@ -30,6 +32,7 @@ pub fn wat2wasm(path: &Path) -> Vec<u8> {
 
     let mut cmd = Command::new("wat2wasm");
     cmd.arg(path)
+        .args(FEATURES)
         .arg("--debug-names")
         .arg("-o")
         .arg(file.path());
@@ -67,6 +70,7 @@ pub fn wasm2wat(path: &Path) -> String {
 
     let mut cmd = Command::new("wasm2wat");
     cmd.arg(path);
+    cmd.args(FEATURES);
     println!("running: {:?}", cmd);
     let output = cmd.output().expect("should spawn wasm2wat OK");
     if !output.status.success() {

--- a/walrus-tests/tests/ir/atomic.wat
+++ b/walrus-tests/tests/ir/atomic.wat
@@ -1,0 +1,74 @@
+(module
+  (memory 1 1 shared)
+
+  (func
+    (i32.atomic.rmw.cmpxchg
+      (i32.const 0)
+      (i32.const 1)
+      (i32.const 2))
+
+    (i32.atomic.rmw.add
+      (i32.const 0)
+      (i32.const 1))
+
+    (atomic.notify
+      (i32.const 0)
+      (i32.const 1))
+
+    (i32.atomic.wait
+      (i32.const 0)
+      (i32.const 1)
+      (i64.const 2)
+      )
+
+    (i64.atomic.wait
+      (i32.const 0)
+      (i64.const 1)
+      (i64.const 2)
+      )
+
+    i32.add
+    i32.add
+    i32.add
+    i32.add
+    drop
+  )
+)
+
+;; CHECK: (func
+;; NEXT:    (block
+;; NEXT:      (drop
+;; NEXT:        (I32Add
+;; NEXT:          (cmpxchg 0
+;; NEXT:            (const 0)
+;; NEXT:            (const 1)
+;; NEXT:            (const 2)
+;; NEXT:          )
+;; NEXT:          (I32Add
+;; NEXT:            (atomic.rmw 0
+;; NEXT:              (const 0)
+;; NEXT:              (const 1)
+;; NEXT:            )
+;; NEXT:            (I32Add
+;; NEXT:              (atomic.notify 0
+;; NEXT:                (const 0)
+;; NEXT:                (const 1)
+;; NEXT:              )
+;; NEXT:              (I32Add
+;; NEXT:                (atomic.wait 0
+;; NEXT:                  (const 0)
+;; NEXT:                  (const 1)
+;; NEXT:                  (const 2)
+;; NEXT:                )
+;; NEXT:                (atomic.wait 0
+;; NEXT:                  (const 0)
+;; NEXT:                  (const 1)
+;; NEXT:                  (const 2)
+;; NEXT:                )
+;; NEXT:              )
+;; NEXT:            )
+;; NEXT:          )
+;; NEXT:        )
+;; NEXT:      )
+;; NEXT:    )
+;; NEXT:  )


### PR DESCRIPTION
This commit implements support for all atomic instructions in `walrus`,
adding definitions for all instructions proposed in the threads proposal
as well as hooking up validation to ensure their usage requires shared
memory.

There's not currently a working spec test for these unfortunately, but
this implementation passes against a modified version of the spec tests
currently upstream which wabt presently rejects due to instruction
renaming. We'll be sure to update to run the spec test once it's been
udpated!