### PR TITLE
Implement some of bulk memory operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ id-arena = { version = "2.1.0", features = ['rayon'] }
 leb128 = "0.2.3"
 log = "0.4"
 rayon = "1.0.3"
-wasmparser = "0.26"
+wasmparser = "0.27"
 
 [dependencies.walrus-derive]
 path = "./walrus-derive"

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -59,8 +59,8 @@ pub struct IdsToIndices {
     pub locals: IdHashMap<Function, IdHashMap<Local, u32>>,
 }
 
-macro_rules! define_get_push_index {
-    ( $get_name:ident, $push_name:ident, $id_ty:ty, $member:ident ) => {
+macro_rules! define_get_index {
+    ( $get_name:ident, $id_ty:ty, $member:ident ) => {
         impl IdsToIndices {
             /// Get the index for the given identifier.
             #[inline]
@@ -72,7 +72,14 @@ macro_rules! define_get_push_index {
                      an unused identifier, or that we are emitting sections in the wrong order."
                 )
             }
+        }
+    };
+}
 
+macro_rules! define_get_push_index {
+    ( $get_name:ident, $push_name:ident, $id_ty:ty, $member:ident ) => {
+        define_get_index!($get_name, $id_ty, $member);
+        impl IdsToIndices {
             /// Adds the given identifier to this set, assigning it the next
             /// available index.
             #[inline]
@@ -90,7 +97,14 @@ define_get_push_index!(get_func_index, push_func, FunctionId, funcs);
 define_get_push_index!(get_global_index, push_global, GlobalId, globals);
 define_get_push_index!(get_memory_index, push_memory, MemoryId, memories);
 define_get_push_index!(get_element_index, push_element, ElementId, elements);
-define_get_push_index!(get_data_index, push_data, DataId, data);
+define_get_index!(get_data_index, DataId, data);
+
+impl IdsToIndices {
+    /// Sets the data index to the specified value
+    pub fn set_data_index(&mut self, id: DataId, idx: u32) {
+        self.data.insert(id, idx);
+    }
+}
 
 impl<'a> EmitContext<'a> {
     pub fn start_section<'b>(&'b mut self, id: Section) -> SubContext<'a, 'b> {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -8,6 +8,7 @@ pub mod matcher;
 
 use crate::dot::Dot;
 use crate::encode::Encoder;
+use crate::module::data::DataId;
 use crate::module::functions::FunctionId;
 use crate::module::functions::{DisplayExpr, DotExpr};
 use crate::module::globals::GlobalId;
@@ -301,6 +302,52 @@ pub enum Expr {
         memory: MemoryId,
         /// The number of pages to grow by.
         pages: ExprId,
+    },
+
+    /// memory.init
+    MemoryInit {
+        /// The memory we're growing.
+        memory: MemoryId,
+        /// The data to copy in
+        data: DataId,
+        /// The offset in bytes in memory
+        memory_offset: ExprId,
+        /// The offset in bytes in the data
+        data_offset: ExprId,
+        /// The number of bytes to copy
+        len: ExprId,
+    },
+
+    /// data.drop
+    DataDrop {
+        /// The data to drop
+        data: DataId,
+    },
+
+    /// memory.copy
+    MemoryCopy {
+        /// The source memory
+        src: MemoryId,
+        /// The destination memory
+        dst: MemoryId,
+        /// The offset in the destination memory
+        dst_offset: ExprId,
+        /// The offset in the source memory
+        src_offset: ExprId,
+        /// The number of bytes to copy
+        len: ExprId,
+    },
+
+    /// memory.fill
+    MemoryFill {
+        /// The memory to fill
+        memory: MemoryId,
+        /// The offset in memory to start filling
+        offset: ExprId,
+        /// The value to fill
+        value: ExprId,
+        /// The number of bytes to fill in
+        len: ExprId,
     },
 
     /// Loading a value from memory
@@ -801,6 +848,10 @@ impl Expr {
             | Expr::IfElse(..)
             | Expr::MemorySize(..)
             | Expr::MemoryGrow(..)
+            | Expr::MemoryInit(..)
+            | Expr::DataDrop(..)
+            | Expr::MemoryCopy(..)
+            | Expr::MemoryFill(..)
             | Expr::CallIndirect(..)
             | Expr::Load(..)
             | Expr::Store(..)

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -87,6 +87,47 @@ impl Emit<'_, '_> {
                 self.encoder.u32(idx);
             }
 
+            MemoryInit(e) => {
+                self.visit(e.memory_offset);
+                self.visit(e.data_offset);
+                self.visit(e.len);
+                self.encoder.raw(&[0xfc, 0x08]); // memory.init
+                let idx = self.indices.get_data_index(e.data);
+                self.encoder.u32(idx);
+                let idx = self.indices.get_memory_index(e.memory);
+                assert_eq!(idx, 0);
+                self.encoder.u32(idx);
+            }
+
+            DataDrop(e) => {
+                self.encoder.raw(&[0xfc, 0x09]); // data.drop
+                let idx = self.indices.get_data_index(e.data);
+                self.encoder.u32(idx);
+            }
+
+            MemoryCopy(e) => {
+                self.visit(e.dst_offset);
+                self.visit(e.src_offset);
+                self.visit(e.len);
+                self.encoder.raw(&[0xfc, 0x0a]); // memory.copy
+                let idx = self.indices.get_memory_index(e.src);
+                assert_eq!(idx, 0);
+                self.encoder.u32(idx);
+                let idx = self.indices.get_memory_index(e.dst);
+                assert_eq!(idx, 0);
+                self.encoder.u32(idx);
+            }
+
+            MemoryFill(e) => {
+                self.visit(e.offset);
+                self.visit(e.value);
+                self.visit(e.len);
+                self.encoder.raw(&[0xfc, 0x0b]); // memory.fill
+                let idx = self.indices.get_memory_index(e.memory);
+                assert_eq!(idx, 0);
+                self.encoder.u32(idx);
+            }
+
             Binop(e) => {
                 use BinaryOp::*;
 

--- a/src/module/memories.rs
+++ b/src/module/memories.rs
@@ -8,6 +8,7 @@ use crate::module::globals::GlobalId;
 use crate::module::imports::ImportId;
 use crate::module::Module;
 use crate::parse::IndicesToIds;
+use crate::passes::Used;
 use id_arena::{Arena, Id};
 
 /// The id of a memory.
@@ -131,6 +132,10 @@ impl ModuleMemories {
     /// Get a shared reference to this module's memories.
     pub fn iter(&self) -> impl Iterator<Item = &Memory> {
         self.arena.iter().map(|(_, f)| f)
+    }
+
+    pub(crate) fn iter_used<'a>(&'a self, used: &'a Used) -> impl Iterator<Item = &'a Memory> + 'a {
+        self.iter().filter(move |m| used.memories.contains(&m.id))
     }
 }
 

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -1,7 +1,7 @@
 use crate::const_value::Const;
 use crate::ir::*;
 use crate::map::{IdHashMap, IdHashSet};
-use crate::module::data::Data;
+use crate::module::data::{Data, DataId};
 use crate::module::elements::Element;
 use crate::module::exports::{ExportId, ExportItem};
 use crate::module::functions::{Function, FunctionId, FunctionKind, LocalFunction};
@@ -188,6 +188,10 @@ impl<'expr> Visitor<'expr> for UsedVisitor<'expr, '_> {
 
     fn visit_type_id(&mut self, &t: &TypeId) {
         self.stack.used.types.insert(t);
+    }
+
+    fn visit_data_id(&mut self, &t: &DataId) {
+        self.stack.used.data.insert(t);
     }
 
     fn visit_local_id(&mut self, &l: &LocalId) {

--- a/walrus-derive/src/lib.rs
+++ b/walrus-derive/src/lib.rs
@@ -497,6 +497,11 @@ fn create_visit(variants: &[WalrusVariant]) -> impl quote::ToTokens {
                 // ...
             }
 
+            /// Visit `DataId`.
+            fn visit_data_id(&mut self, function: &crate::module::data::DataId) {
+                // ...
+            }
+
             /// Visit `TypeId`
             fn visit_type_id(&mut self, ty: &crate::ty::TypeId) {
                 // ...
@@ -719,6 +724,10 @@ fn create_display(variants: &[WalrusVariant]) -> impl quote::ToTokens {
                 self.id(*ty);
             }
 
+            fn visit_data_id(&mut self, data: &crate::module::data::DataId) {
+                self.id(*data);
+            }
+
             fn visit_value(&mut self, value: &crate::ir::Value) {
                 self.f.push_str(" ");
                 self.f.push_str(&value.to_string());
@@ -801,6 +810,10 @@ fn create_dot(variants: &[WalrusVariant]) -> impl quote::ToTokens {
 
             fn visit_type_id(&mut self, ty: &crate::ty::TypeId) {
                 self.id(*ty);
+            }
+
+            fn visit_data_id(&mut self, data: &crate::module::data::DataId) {
+                self.id(*data);
             }
 
             fn visit_value(&mut self, value: &crate::ir::Value) {

--- a/walrus-tests-utils/src/lib.rs
+++ b/walrus-tests-utils/src/lib.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Once, ONCE_INIT};
 
-pub const FEATURES: &[&str] = &["--enable-threads"];
+pub const FEATURES: &[&str] = &["--enable-threads", "--enable-bulk-memory"];
 
 fn require_wat2wasm() {
     let status = Command::new("wat2wasm")

--- a/walrus-tests/tests/ir/bulk-memory.wat
+++ b/walrus-tests/tests/ir/bulk-memory.wat
@@ -1,0 +1,46 @@
+(module
+  (memory 1)
+
+  (func
+    (memory.init 0
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3))
+    (data.drop 2)
+
+    (memory.copy
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3))
+
+    (memory.fill
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3))
+  )
+
+  (data passive "A")
+  (data (i32.const 0) "b")
+  (data passive "C")
+)
+
+;; CHECK: (func
+;; NEXT:    (block
+;; NEXT:      (memory.init 0 0
+;; NEXT:        (const 1)
+;; NEXT:        (const 2)
+;; NEXT:        (const 3)
+;; NEXT:      )
+;; NEXT:      (data.drop 2)
+;; NEXT:      (memory.copy 0 0
+;; NEXT:        (const 1)
+;; NEXT:        (const 2)
+;; NEXT:        (const 3)
+;; NEXT:      )
+;; NEXT:      (memory.fill 0
+;; NEXT:        (const 1)
+;; NEXT:        (const 2)
+;; NEXT:        (const 3)
+;; NEXT:      )
+;; NEXT:    )
+;; NEXT:  )

--- a/walrus-tests/tests/round_trip/bulk-memory.wat
+++ b/walrus-tests/tests/round_trip/bulk-memory.wat
@@ -1,0 +1,47 @@
+(module
+  (memory 1)
+
+  (func (export "a")
+    (memory.init 0
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3))
+    (data.drop 2)
+
+    (memory.copy
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3))
+
+    (memory.fill
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3))
+  )
+
+  (data passive "A")
+  (data (i32.const 0) "b")
+  (data passive "C")
+)
+
+;; CHECK: (module
+;; NEXT:    (type (;0;) (func))
+;; NEXT:    (func (;0;) (type 0)
+;; NEXT:      i32.const 1
+;; NEXT:      i32.const 2
+;; NEXT:      i32.const 3
+;; NEXT:      memory.init 1
+;; NEXT:      data.drop 2
+;; NEXT:      i32.const 1
+;; NEXT:      i32.const 2
+;; NEXT:      i32.const 3
+;; NEXT:      memory.copy
+;; NEXT:      i32.const 1
+;; NEXT:      i32.const 2
+;; NEXT:      i32.const 3
+;; NEXT:      memory.fill)
+;; NEXT:    (memory (;0;) 1)
+;; NEXT:    (export "a" (func 0))
+;; NEXT:    (data (;0;) (i32.const 0) "b")
+;; NEXT:    (data (;1;) passive "A")
+;; NEXT:    (data (;2;) passive "C"))


### PR DESCRIPTION
This commit implements the memory-related pieces of the bulk memory
operations proposal. This doesn't currently implement the pieces for
tables because passive table elements depend on `ref.null` and
`ref.func`, both of which are still somewhat up in the air in the
reference types proposal. For now though we can get the benefit of
passive memory initialization as well as memory copies/fills/etc.