### PR TITLE
VisitMut, FunctionBuilder, other conveniences

### DIFF
--- a/src/const_value.rs
+++ b/src/const_value.rs
@@ -9,7 +9,7 @@ use failure::bail;
 
 /// A constant which is produced in WebAssembly, typically used in global
 /// initializers or element/data offsets.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum Const {
     /// An immediate constant value
     Value(Value),

--- a/src/function_builder.rs
+++ b/src/function_builder.rs
@@ -1,0 +1,181 @@
+use crate::ir::*;
+use crate::module::functions::{FunctionId, LocalFunction};
+use crate::module::Module;
+use crate::ty::{TypeId, ValType};
+use id_arena::Arena;
+use std::mem;
+use std::ops::{Deref, DerefMut, Drop};
+
+/// A helpful struct used for building instances of `LocalFunction`
+#[derive(Default, Debug)]
+pub struct FunctionBuilder {
+    arena: Arena<Expr>,
+}
+
+impl FunctionBuilder {
+    /// Creates a new blank builder ready to build a function.
+    pub fn new() -> FunctionBuilder {
+        FunctionBuilder::default()
+    }
+
+    pub(crate) fn alloc<T>(&mut self, val: T) -> T::Id
+    where
+        T: Ast,
+    {
+        let id = self.arena.alloc(val.into());
+        T::new_id(id)
+    }
+
+    /// Create a `Block` node with the kind of `Block`.
+    ///
+    /// Note that instructions aren't passed here, but rather added to the
+    /// returned `BlockBuilder` via the `expr` method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use walrus::FunctionBuilder;
+    ///
+    /// let mut builder = FunctionBuilder::new();
+    /// let block = {
+    ///     let mut block = builder.block(Box::new([]), Box::new([]));
+    ///     let id = block.id();
+    ///     let br = block.br(id, Box::new([]));
+    ///     block.expr(br);
+    ///     id
+    /// }; // when `block` is `Drop`'d it'll fill in the node's expressions
+    ///
+    /// // ...
+    /// ```
+    pub fn block<'a>(
+        &'a mut self,
+        params: Box<[ValType]>,
+        results: Box<[ValType]>,
+    ) -> BlockBuilder<'a> {
+        self.block_builder(Block {
+            kind: BlockKind::Block,
+            params,
+            results,
+            exprs: Vec::new(),
+        })
+    }
+
+    /// Create a `Block` node with the kind of `Loop`
+    pub fn loop_<'a>(&'a mut self, results: Box<[ValType]>) -> BlockBuilder<'a> {
+        self.block_builder(Block {
+            kind: BlockKind::Block,
+            params: Vec::new().into_boxed_slice(),
+            results,
+            exprs: Vec::new(),
+        })
+    }
+
+    /// Create a `Block` node with the kind of `IfElse`
+    pub fn if_else_block<'a>(
+        &'a mut self,
+        params: Box<[ValType]>,
+        results: Box<[ValType]>,
+    ) -> BlockBuilder<'a> {
+        self.block_builder(Block {
+            kind: BlockKind::IfElse,
+            params,
+            results,
+            exprs: Vec::new(),
+        })
+    }
+
+    fn block_builder<'a>(&'a mut self, block: Block) -> BlockBuilder<'a> {
+        let id = self.alloc(block);
+        BlockBuilder {
+            id,
+            builder: self,
+            exprs: Vec::new(),
+        }
+    }
+
+    /// Creates an `i32.const` instruction for the specified value
+    pub fn i32_const(&mut self, val: i32) -> ExprId {
+        self.const_(Value::I32(val))
+    }
+
+    /// Creates an `i64.const` instruction for the specified value
+    pub fn i64_const(&mut self, val: i64) -> ExprId {
+        self.const_(Value::I64(val))
+    }
+
+    /// Creates an `f32.const` instruction for the specified value
+    pub fn f32_const(&mut self, val: f32) -> ExprId {
+        self.const_(Value::F32(val))
+    }
+
+    /// Creates an `f64.const` instruction for the specified value
+    pub fn f64_const(&mut self, val: f64) -> ExprId {
+        self.const_(Value::F64(val))
+    }
+
+    /// Finishes this builder, wrapping it all up and inserting it into the
+    /// specified `Module`.
+    pub fn finish(
+        mut self,
+        ty_id: TypeId,
+        args: Vec<LocalId>,
+        exprs: Vec<ExprId>,
+        module: &mut Module,
+    ) -> FunctionId {
+        let ty = module.types.get(ty_id);
+        let entry = self.alloc(Block {
+            kind: BlockKind::FunctionEntry,
+            params: ty.params().to_vec().into_boxed_slice(),
+            results: ty.results().to_vec().into_boxed_slice(),
+            exprs,
+        });
+        let func = LocalFunction::new(ty_id, args, self.arena, entry);
+        module.funcs.add_local(func)
+    }
+}
+
+/// A builder returned by block-construction methods to build up block
+/// expressions over time.
+#[derive(Debug)]
+pub struct BlockBuilder<'a> {
+    id: BlockId,
+    builder: &'a mut FunctionBuilder,
+    exprs: Vec<ExprId>,
+}
+
+impl BlockBuilder<'_> {
+    /// Pushes a new expression to be executed in the block we're building
+    pub fn expr(&mut self, expr: ExprId) {
+        self.exprs.push(expr);
+    }
+
+    /// Returns the id of the block that we're building
+    pub fn id(&self) -> BlockId {
+        self.id
+    }
+}
+
+impl Deref for BlockBuilder<'_> {
+    type Target = FunctionBuilder;
+
+    fn deref(&self) -> &FunctionBuilder {
+        &*self.builder
+    }
+}
+
+impl DerefMut for BlockBuilder<'_> {
+    fn deref_mut(&mut self) -> &mut FunctionBuilder {
+        &mut *self.builder
+    }
+}
+
+impl Drop for BlockBuilder<'_> {
+    fn drop(&mut self) {
+        let exprs = mem::replace(&mut self.exprs, Vec::new());
+        let block = match &mut self.builder.arena[self.id.into()] {
+            Expr::Block(b) => b,
+            _ => unreachable!(),
+        };
+        block.exprs = exprs;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,12 @@ pub mod dot;
 mod emit;
 mod encode;
 pub mod error;
+mod function_builder;
 pub mod ir;
 mod map;
 pub mod module;
 mod parse;
 pub mod passes;
 pub mod ty;
+
+pub use crate::function_builder::FunctionBuilder;

--- a/src/module/data.rs
+++ b/src/module/data.rs
@@ -62,6 +62,16 @@ impl ModuleData {
         self.arena.iter().map(|(_, f)| f)
     }
 
+    /// Adds a new passive data segment with the specified contents
+    pub fn add(&mut self, value: Vec<u8>) -> DataId {
+        let id = self.arena.next_id();
+        self.arena.alloc(Data {
+            passive: true,
+            value,
+            id,
+        })
+    }
+
     pub(crate) fn iter_used<'a>(&'a self, used: &'a Used) -> impl Iterator<Item = &'a Data> + 'a {
         self.iter().filter(move |data| used.data.contains(&data.id))
     }

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -44,11 +44,26 @@ pub struct LocalFunction {
 }
 
 impl LocalFunction {
+    /// Creates a new definition of a local function from its components
+    pub(crate) fn new(
+        ty: TypeId,
+        args: Vec<LocalId>,
+        exprs: Arena<Expr>,
+        entry: BlockId,
+    ) -> LocalFunction {
+        LocalFunction {
+            ty,
+            args,
+            entry: Some(entry),
+            exprs,
+        }
+    }
+
     /// Construct a new `LocalFunction`.
     ///
     /// Validates the given function body and constructs the `Expr` IR at the
     /// same time.
-    pub fn parse(
+    pub(crate) fn parse(
         module: &Module,
         indices: &IndicesToIds,
         id: FunctionId,

--- a/src/module/functions/mod.rs
+++ b/src/module/functions/mod.rs
@@ -188,6 +188,58 @@ impl ModuleFunctions {
         self.arena.par_iter().map(|(_, f)| f)
     }
 
+    /// Get an iterator of this module's local functions
+    pub fn iter_local(&self) -> impl Iterator<Item = (FunctionId, &LocalFunction)> {
+        self.iter().filter_map(|f| {
+            match &f.kind {
+                FunctionKind::Local(local) => Some((f.id(), local)),
+                _ => None,
+            }
+        })
+    }
+
+    /// Get a parallel iterator of this module's local functions
+    pub fn par_iter_local(&self) -> impl ParallelIterator<Item = (FunctionId, &LocalFunction)> {
+        self.par_iter().filter_map(|f| {
+            match &f.kind {
+                FunctionKind::Local(local) => Some((f.id(), local)),
+                _ => None,
+            }
+        })
+    }
+
+    /// Get a mutable reference to this module's functions.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Function> {
+        self.arena.iter_mut().map(|(_, f)| f)
+    }
+
+    /// Get a mutable reference to this module's functions.
+    pub fn par_iter_mut(&mut self) -> impl ParallelIterator<Item = &mut Function> {
+        self.arena.par_iter_mut().map(|(_, f)| f)
+    }
+
+    /// Get an iterator of this module's local functions
+    pub fn iter_local_mut(&mut self) -> impl Iterator<Item = (FunctionId, &mut LocalFunction)> {
+        self.iter_mut().filter_map(|f| {
+            let id = f.id();
+            match &mut f.kind {
+                FunctionKind::Local(local) => Some((id, local)),
+                _ => None,
+            }
+        })
+    }
+
+    /// Get a parallel iterator of this module's local functions
+    pub fn par_iter_local_mut(&mut self) -> impl ParallelIterator<Item = (FunctionId, &mut LocalFunction)> {
+        self.par_iter_mut().filter_map(|f| {
+            let id = f.id();
+            match &mut f.kind {
+                FunctionKind::Local(local) => Some((id, local)),
+                _ => None,
+            }
+        })
+    }
+
     pub(crate) fn iter_used<'a>(
         &'a self,
         used: &'a Used,

--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -60,6 +60,15 @@ impl ModuleImports {
     pub fn iter(&self) -> impl Iterator<Item = &Import> {
         self.arena.iter().map(|(_, f)| f)
     }
+
+    /// Adds a new import to this module
+    pub fn add(&mut self, module: &str, name: &str, kind: ImportKind) -> ImportId {
+        self.arena.insert(Import {
+            module: module.to_string(),
+            name: name.to_string(),
+            kind,
+        })
+    }
 }
 
 impl Module {

--- a/src/module/memories.rs
+++ b/src/module/memories.rs
@@ -134,6 +134,11 @@ impl ModuleMemories {
         self.arena.iter().map(|(_, f)| f)
     }
 
+    /// Get a mutable reference to this module's memories.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Memory> {
+        self.arena.iter_mut().map(|(_, f)| f)
+    }
+
     pub(crate) fn iter_used<'a>(&'a self, used: &'a Used) -> impl Iterator<Item = &'a Memory> + 'a {
         self.iter().filter(move |m| used.memories.contains(&m.id))
     }
@@ -201,5 +206,18 @@ impl MemoryData {
     /// Returns an iterator of all globals used as relative bases
     pub fn globals<'a>(&'a self) -> impl Iterator<Item = GlobalId> + 'a {
         self.relative.iter().map(|p| p.0)
+    }
+
+    /// Consumes this data and returns a by-value iterator of each segment
+    pub fn into_iter(self) -> impl Iterator<Item = (Const, Vec<u8>)> {
+        let absolute = self
+            .absolute
+            .into_iter()
+            .map(move |(pos, data)| (Const::Value(Value::I32(pos as i32)), data));
+        let relative = self
+            .relative
+            .into_iter()
+            .map(move |(id, data)| (Const::Global(id), data));
+        absolute.chain(relative)
     }
 }

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -34,21 +34,28 @@ use std::path::Path;
 
 /// A wasm module.
 #[derive(Debug, Default)]
+#[allow(missing_docs)]
 pub struct Module {
-    pub(crate) imports: ModuleImports,
-    pub(crate) tables: ModuleTables,
-    pub(crate) types: ModuleTypes,
-    pub(crate) funcs: ModuleFunctions,
-    pub(crate) globals: ModuleGlobals,
-    pub(crate) locals: ModuleLocals,
-    pub(crate) exports: ModuleExports,
-    pub(crate) memories: ModuleMemories,
-    pub(crate) data: ModuleData,
-    pub(crate) elements: ModuleElements,
-    pub(crate) start: Option<FunctionId>,
+    pub imports: ModuleImports,
+    pub tables: ModuleTables,
+    pub types: ModuleTypes,
+    pub funcs: ModuleFunctions,
+    pub globals: ModuleGlobals,
+    pub locals: ModuleLocals,
+    pub exports: ModuleExports,
+    pub memories: ModuleMemories,
+    /// Registration of passive data segments, if any
+    pub data: ModuleData,
+    /// Registration of passive element segments, if any
+    pub elements: ModuleElements,
+    /// The `start` function, if any
+    pub start: Option<FunctionId>,
+    /// Representation of the eventual custom section, `producers`
+    pub producers: ModuleProducers,
     custom: Vec<CustomSection>,
-    name: Option<String>,
-    pub(crate) producers: ModuleProducers,
+    /// The name of this module, used for debugging purposes in the `name`
+    /// custom section.
+    pub name: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/module/types.rs
+++ b/src/module/types.rs
@@ -28,6 +28,16 @@ impl ModuleTypes {
     pub fn iter(&self) -> impl Iterator<Item = &Type> {
         self.arena.iter().map(|(_, f)| f)
     }
+
+    /// Add a new type to this module, and return its `Id`
+    pub fn add(&mut self, params: &[ValType], results: &[ValType]) -> TypeId {
+        let id = self.arena.next_id();
+        self.arena.insert(Type::new(
+            id,
+            params.to_vec().into_boxed_slice(),
+            results.to_vec().into_boxed_slice(),
+        ))
+    }
 }
 
 impl Module {


### PR DESCRIPTION
In transitioning some code in `wasm-bindgen` to using `walrus` I ended
up adding a number of types and things to `walrus`, notably:

* A `FunctionBuilder` type is now available to build a `LocalFunction`
  programmatically. This type has a associated function for each IR node
  (the arguments being the node's components) which is auto-generated.
  It then has special methods for handling blocks to ensure that block
  IDs can be generated ahead-of-time.

* A `VisitMut` and `VisitorMut` pair of traits is intended to mirror the
  `Visit` and `Visitor` traits, only be mutable versions. Currently they
  have a 1:1 correspondance except for `&` vs `&mut`. I'm not entirely
  sure how this will play out long-term, but I figure it's a good start.

  The most notable part here is `VisitMut for ExprId` which *removes* an
  expression from the arena (replacing it with a dummy expression),
  visits mutably recursively, and then re-inserts it back into the
  arena. This should work for now but may pose problems once we have a
  DAG of an IR instead of a tree.

* A few other conveniences for iterating and such have been added. As a
  public API I've gone ahead an made most of the fields of `Module`
  public. I think that's actually how we may want the public API to play
  out long-term as well, as it nicely allows for sub-borrows of just one
  class of item in wasm modules.