### PR TITLE
Add a `ModuleConfig` option for generating debug parser names

### DIFF
--- a/src/module/config.rs
+++ b/src/module/config.rs
@@ -1,0 +1,31 @@
+use crate::error::Result;
+use crate::module::Module;
+
+/// Configuration for a `Module` which currently affects parsing.
+#[derive(Clone, Debug, Default)]
+pub struct ModuleConfig {
+    pub(crate) generate_names: bool,
+}
+
+impl ModuleConfig {
+    /// Creates a fresh new configuration with default settings.
+    pub fn new() -> ModuleConfig {
+        ModuleConfig::default()
+    }
+
+    /// Sets a flag to whether debugging names are generated for
+    /// locals/functions/etc when parsing and running passes for this module.
+    ///
+    /// By default this flag is `false`, and it will generate quite a few names
+    /// if enabled!
+    pub fn generate_names(&mut self, generate: bool) -> &mut ModuleConfig {
+        self.generate_names = generate;
+        self
+    }
+
+    /// Parses an in-memroy WebAssembly file into a `Module` using this
+    /// configuration.
+    pub fn parse(&mut self, wasm: &[u8]) -> Result<Module> {
+        Module::parse(wasm, self)
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,8 +26,9 @@ macro_rules! define_push_get {
     ( $push:ident, $get:ident, $id_ty:ty, $member:ident ) => {
         impl IndicesToIds {
             /// Pushes a new local ID to map it to the next index internally
-            pub fn $push(&mut self, id: $id_ty) {
+            pub fn $push(&mut self, id: $id_ty) -> u32 {
                 self.$member.push(id);
+                (self.$member.len() - 1) as u32
             }
 
             /// Gets the ID for a particular index
@@ -55,8 +56,10 @@ define_push_get!(push_data, get_data, DataId, data);
 
 impl IndicesToIds {
     /// Pushes a new local ID to map it to the next index internally
-    pub fn push_local(&mut self, function: FunctionId, id: LocalId) {
-        self.locals.entry(function).or_insert(Vec::new()).push(id);
+    pub fn push_local(&mut self, function: FunctionId, id: LocalId) -> u32 {
+        let list = self.locals.entry(function).or_insert(Vec::new());
+        list.push(id);
+        (list.len() as u32) - 1
     }
 
     /// Gets the ID for a particular index


### PR DESCRIPTION
This commit starts by growing a `ModuleConfig` structure to place global
configuration for parsing WebAssembly and other sorts of module
configuration. The first option added is one to flag whether or not
debug names should be generated for all IR nodes.

When set, this option will ensure that all functions and locals have a
debug name configured. By default they're all based on the original
indices in the wasm file itself, and then the `name` section, if
present, takes precedent.

This'll also be used by lowering passes so when temporary locals are
created they can be given helpful debugging names as well