### PR TITLE
Reorganize the crate with less namespaces

### DIFF
--- a/crates/fuzz/src/lib.rs
+++ b/crates/fuzz/src/lib.rs
@@ -72,7 +72,7 @@ impl Config {
     }
 
     fn round_trip_through_walrus(&self, wasm: &[u8]) -> Vec<u8> {
-        walrus::module::Module::from_buffer(&wasm)
+        walrus::Module::from_buffer(&wasm)
             .unwrap()
             .emit_wasm()
             .unwrap()

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -506,7 +506,7 @@ fn create_visit(variants: &[WalrusVariant]) -> impl quote::ToTokens {
         /// A visitor walks over an IR expression tree.
         pub trait Visitor<'expr>: Sized {
             /// Return the local function we're visiting
-            fn local_function(&self) -> &'expr crate::module::functions::LocalFunction;
+            fn local_function(&self) -> &'expr crate::LocalFunction;
 
             /// Visit `Expr`.
             fn visit_expr(&mut self, expr: &'expr Expr) {
@@ -519,37 +519,37 @@ fn create_visit(variants: &[WalrusVariant]) -> impl quote::ToTokens {
             }
 
             /// Visit `Local`.
-            fn visit_local_id(&mut self, local: &crate::ir::LocalId) {
+            fn visit_local_id(&mut self, local: &crate::LocalId) {
                 // ...
             }
 
             /// Visit `Memory`.
-            fn visit_memory_id(&mut self, memory: &crate::module::memories::MemoryId) {
+            fn visit_memory_id(&mut self, memory: &crate::MemoryId) {
                 // ...
             }
 
             /// Visit `Table`.
-            fn visit_table_id(&mut self, table: &crate::module::tables::TableId) {
+            fn visit_table_id(&mut self, table: &crate::TableId) {
                 // ...
             }
 
             /// Visit `GlobalId`.
-            fn visit_global_id(&mut self, global: &crate::module::globals::GlobalId) {
+            fn visit_global_id(&mut self, global: &crate::GlobalId) {
                 // ...
             }
 
             /// Visit `FunctionId`.
-            fn visit_function_id(&mut self, function: &crate::module::functions::FunctionId) {
+            fn visit_function_id(&mut self, function: &crate::FunctionId) {
                 // ...
             }
 
             /// Visit `DataId`.
-            fn visit_data_id(&mut self, function: &crate::module::data::DataId) {
+            fn visit_data_id(&mut self, function: &crate::DataId) {
                 // ...
             }
 
             /// Visit `TypeId`
-            fn visit_type_id(&mut self, ty: &crate::ty::TypeId) {
+            fn visit_type_id(&mut self, ty: &crate::TypeId) {
                 // ...
             }
 
@@ -564,7 +564,7 @@ fn create_visit(variants: &[WalrusVariant]) -> impl quote::ToTokens {
         /// A visitor walks over a mutable IR expression tree.
         pub trait VisitorMut: Sized {
             /// Return the local function we're visiting
-            fn local_function_mut(&mut self) -> &mut crate::module::functions::LocalFunction;
+            fn local_function_mut(&mut self) -> &mut crate::LocalFunction;
 
             /// Visit `Expr`.
             fn visit_expr_mut(&mut self, expr: &mut Expr) {
@@ -577,37 +577,37 @@ fn create_visit(variants: &[WalrusVariant]) -> impl quote::ToTokens {
             }
 
             /// Visit `Local`.
-            fn visit_local_id_mut(&mut self, local: &mut crate::ir::LocalId) {
+            fn visit_local_id_mut(&mut self, local: &mut crate::LocalId) {
                 // ...
             }
 
             /// Visit `Memory`.
-            fn visit_memory_id_mut(&mut self, memory: &mut crate::module::memories::MemoryId) {
+            fn visit_memory_id_mut(&mut self, memory: &mut crate::MemoryId) {
                 // ...
             }
 
             /// Visit `Table`.
-            fn visit_table_id_mut(&mut self, table: &mut crate::module::tables::TableId) {
+            fn visit_table_id_mut(&mut self, table: &mut crate::TableId) {
                 // ...
             }
 
             /// Visit `GlobalId`.
-            fn visit_global_id_mut(&mut self, global: &mut crate::module::globals::GlobalId) {
+            fn visit_global_id_mut(&mut self, global: &mut crate::GlobalId) {
                 // ...
             }
 
             /// Visit `FunctionId`.
-            fn visit_function_id_mut(&mut self, function: &mut crate::module::functions::FunctionId) {
+            fn visit_function_id_mut(&mut self, function: &mut crate::FunctionId) {
                 // ...
             }
 
             /// Visit `DataId`.
-            fn visit_data_id_mut(&mut self, function: &mut crate::module::data::DataId) {
+            fn visit_data_id_mut(&mut self, function: &mut crate::DataId) {
                 // ...
             }
 
             /// Visit `TypeId`
-            fn visit_type_id_mut(&mut self, ty: &mut crate::ty::TypeId) {
+            fn visit_type_id_mut(&mut self, ty: &mut crate::TypeId) {
                 // ...
             }
 
@@ -767,7 +767,7 @@ fn create_matchers(variants: &[WalrusVariant]) -> impl quote::ToTokens {
     quote! {
         pub(crate) mod generated_matchers {
             use crate::ir::*;
-            use crate::module::functions::LocalFunction;
+            use crate::LocalFunction;
             use super::matcher::Matcher;
 
             #( #matchers )*
@@ -804,8 +804,8 @@ fn create_display(variants: &[WalrusVariant]) -> impl quote::ToTokens {
         });
     }
     quote! {
-        impl<'expr> Visitor<'expr> for crate::module::functions::DisplayExpr<'expr, '_> {
-            fn local_function(&self) -> &'expr crate::module::functions::LocalFunction {
+        impl<'expr> Visitor<'expr> for crate::module::DisplayExpr<'expr, '_> {
+            fn local_function(&self) -> &'expr crate::LocalFunction {
                 self.func
             }
 
@@ -813,31 +813,31 @@ fn create_display(variants: &[WalrusVariant]) -> impl quote::ToTokens {
                 self.expr_id(*expr)
             }
 
-            fn visit_local_id(&mut self, local: &crate::ir::LocalId) {
+            fn visit_local_id(&mut self, local: &crate::LocalId) {
                 self.id(*local);
             }
 
-            fn visit_memory_id(&mut self, memory: &crate::module::memories::MemoryId) {
+            fn visit_memory_id(&mut self, memory: &crate::MemoryId) {
                 self.id(*memory);
             }
 
-            fn visit_table_id(&mut self, table: &crate::module::tables::TableId) {
+            fn visit_table_id(&mut self, table: &crate::TableId) {
                 self.id(*table);
             }
 
-            fn visit_global_id(&mut self, global: &crate::module::globals::GlobalId) {
+            fn visit_global_id(&mut self, global: &crate::GlobalId) {
                 self.id(*global);
             }
 
-            fn visit_function_id(&mut self, function: &crate::module::functions::FunctionId) {
+            fn visit_function_id(&mut self, function: &crate::FunctionId) {
                 self.id(*function);
             }
 
-            fn visit_type_id(&mut self, ty: &crate::ty::TypeId) {
+            fn visit_type_id(&mut self, ty: &crate::TypeId) {
                 self.id(*ty);
             }
 
-            fn visit_data_id(&mut self, data: &crate::module::data::DataId) {
+            fn visit_data_id(&mut self, data: &crate::DataId) {
                 self.id(*data);
             }
 
@@ -892,8 +892,8 @@ fn create_dot(variants: &[WalrusVariant]) -> impl quote::ToTokens {
         });
     }
     quote! {
-        impl<'expr> Visitor<'expr> for crate::module::functions::DotExpr<'_, 'expr> {
-            fn local_function(&self) -> &'expr crate::module::functions::LocalFunction {
+        impl<'expr> Visitor<'expr> for crate::module::DotExpr<'_, 'expr> {
+            fn local_function(&self) -> &'expr crate::LocalFunction {
                 self.func
             }
 
@@ -901,31 +901,31 @@ fn create_dot(variants: &[WalrusVariant]) -> impl quote::ToTokens {
                 self.expr_id(*expr);
             }
 
-            fn visit_local_id(&mut self, local: &crate::ir::LocalId) {
+            fn visit_local_id(&mut self, local: &crate::LocalId) {
                 self.id(*local);
             }
 
-            fn visit_memory_id(&mut self, memory: &crate::module::memories::MemoryId) {
+            fn visit_memory_id(&mut self, memory: &crate::MemoryId) {
                 self.id(*memory);
             }
 
-            fn visit_table_id(&mut self, table: &crate::module::tables::TableId) {
+            fn visit_table_id(&mut self, table: &crate::TableId) {
                 self.id(*table);
             }
 
-            fn visit_global_id(&mut self, global: &crate::module::globals::GlobalId) {
+            fn visit_global_id(&mut self, global: &crate::GlobalId) {
                 self.id(*global);
             }
 
-            fn visit_function_id(&mut self, function: &crate::module::functions::FunctionId) {
+            fn visit_function_id(&mut self, function: &crate::FunctionId) {
                 self.id(*function);
             }
 
-            fn visit_type_id(&mut self, ty: &crate::ty::TypeId) {
+            fn visit_type_id(&mut self, ty: &crate::TypeId) {
                 self.id(*ty);
             }
 
-            fn visit_data_id(&mut self, data: &crate::module::data::DataId) {
+            fn visit_data_id(&mut self, data: &crate::DataId) {
                 self.id(*data);
             }
 

--- a/crates/tests/tests/ir.rs
+++ b/crates/tests/tests/ir.rs
@@ -5,12 +5,12 @@ use walrus::dot::Dot;
 
 fn run(wat_path: &Path) -> Result<(), failure::Error> {
     let wasm = walrus_tests_utils::wat2wasm(wat_path);
-    let module = walrus::module::Module::from_buffer(&wasm)?;
+    let module = walrus::Module::from_buffer(&wasm)?;
 
     let local_funcs: Vec<_> = module
         .functions()
         .filter(|f| match f.kind {
-            walrus::module::functions::FunctionKind::Local(_) => true,
+            walrus::FunctionKind::Local(_) => true,
             _ => false,
         })
         .collect();

--- a/crates/tests/tests/round_trip.rs
+++ b/crates/tests/tests/round_trip.rs
@@ -6,7 +6,7 @@ use walrus_tests_utils::{wasm2wat, wat2wasm};
 
 fn run(wat_path: &Path) -> Result<(), failure::Error> {
     let wasm = wat2wasm(wat_path);
-    let module = walrus::module::Module::from_buffer(&wasm)?;
+    let module = walrus::Module::from_buffer(&wasm)?;
 
     if env::var("WALRUS_TESTS_DOT").is_ok() {
         for (i, func) in module.functions().enumerate() {

--- a/crates/tests/tests/spec-tests.rs
+++ b/crates/tests/tests/spec-tests.rs
@@ -64,7 +64,7 @@ fn run(wast: &Path) -> Result<(), failure::Error> {
         let path = tempdir.path().join(filename);
         match command["type"].as_str().unwrap() {
             "assert_invalid" | "assert_malformed" => {
-                if walrus::module::Module::from_file(&path).is_ok() {
+                if walrus::Module::from_file(&path).is_ok() {
                     panic!("wasm parsed when it shouldn't (line {})", line);
                 }
             }
@@ -78,7 +78,7 @@ fn run(wast: &Path) -> Result<(), failure::Error> {
                 // much, but that's another bug for another day.
             }
             cmd => {
-                let mut wasm = walrus::module::Module::from_file(&path)
+                let mut wasm = walrus::Module::from_file(&path)
                     .context(format!("error parsing wasm (line {})", line))?;
 
                 // If a module is supposed to be unlinkable we'll often gc out
@@ -107,7 +107,7 @@ fn run(wast: &Path) -> Result<(), failure::Error> {
                     .emit_wasm()
                     .context(format!("error emitting wasm (line {})", line))?;
                 fs::write(&path, &wasm1)?;
-                let wasm2 = walrus::module::Module::from_buffer(&wasm1)
+                let wasm2 = walrus::Module::from_buffer(&wasm1)
                     .and_then(|m| m.emit_wasm())
                     .context(format!("error re-parsing wasm (line {})", line))?;
                 if wasm1 != wasm2 {

--- a/crates/tests/tests/valid.rs
+++ b/crates/tests/tests/valid.rs
@@ -5,12 +5,12 @@ use walrus::dot::Dot;
 
 fn run(wat: &Path) -> Result<(), failure::Error> {
     let wasm = walrus_tests_utils::wat2wasm(wat);
-    let module = walrus::module::Module::from_buffer(&wasm)?;
+    let module = walrus::Module::from_buffer(&wasm)?;
 
     let local_funcs: Vec<_> = module
         .functions()
         .filter(|f| match f.kind {
-            walrus::module::functions::FunctionKind::Local(_) => true,
+            walrus::FunctionKind::Local(_) => true,
             _ => false,
         })
         .collect();

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -4,5 +4,5 @@
 fn main() {
     env_logger::init();
     let a = std::env::args().nth(1).unwrap();
-    walrus::module::Module::from_file(a).unwrap();
+    walrus::Module::from_file(a).unwrap();
 }

--- a/examples/round-trip.rs
+++ b/examples/round-trip.rs
@@ -3,7 +3,7 @@
 fn main() {
     env_logger::init();
     let a = std::env::args().nth(1).unwrap();
-    let m = walrus::module::Module::from_file(&a).unwrap();
+    let m = walrus::Module::from_file(&a).unwrap();
     let wasm = m.emit_wasm().unwrap();
     if let Some(destination) = std::env::args().nth(2) {
         std::fs::write(destination, wasm).unwrap();

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -5,15 +5,10 @@
 use crate::encode::{Encoder, MAX_U32_LENGTH};
 use crate::ir::Local;
 use crate::map::IdHashMap;
-use crate::module::data::{Data, DataId};
-use crate::module::elements::{Element, ElementId};
-use crate::module::functions::{Function, FunctionId};
-use crate::module::globals::{Global, GlobalId};
-use crate::module::memories::{Memory, MemoryId};
-use crate::module::tables::{Table, TableId};
-use crate::module::Module;
 use crate::passes::Used;
-use crate::ty::{Type, TypeId};
+use crate::{Data, DataId, Element, ElementId, Function, FunctionId};
+use crate::{Global, GlobalId, Memory, MemoryId, Module, Table, TableId};
+use crate::{Type, TypeId};
 use std::ops::{Deref, DerefMut};
 
 pub struct EmitContext<'a> {

--- a/src/function_builder.rs
+++ b/src/function_builder.rs
@@ -1,7 +1,5 @@
 use crate::ir::*;
-use crate::module::functions::{FunctionId, LocalFunction};
-use crate::module::Module;
-use crate::ty::{TypeId, ValType};
+use crate::{FunctionId, LocalFunction, Module, TypeId, ValType};
 use id_arena::Arena;
 use std::mem;
 use std::ops::{Deref, DerefMut, Drop};

--- a/src/init_expr.rs
+++ b/src/init_expr.rs
@@ -1,32 +1,31 @@
 //! Handling wasm constant values
 
 use crate::emit::{Emit, EmitContext};
-use crate::error::Result;
 use crate::ir::Value;
-use crate::module::globals::GlobalId;
 use crate::parse::IndicesToIds;
+use crate::{GlobalId, Result};
 use failure::bail;
 
 /// A constant which is produced in WebAssembly, typically used in global
 /// initializers or element/data offsets.
 #[derive(Debug, Copy, Clone)]
-pub enum Const {
+pub enum InitExpr {
     /// An immediate constant value
     Value(Value),
     /// A constant value referenced by the global specified
     Global(GlobalId),
 }
 
-impl Const {
-    pub(crate) fn eval(init: &wasmparser::InitExpr, ids: &IndicesToIds) -> Result<Const> {
+impl InitExpr {
+    pub(crate) fn eval(init: &wasmparser::InitExpr, ids: &IndicesToIds) -> Result<InitExpr> {
         use wasmparser::Operator::*;
         let mut reader = init.get_operators_reader();
         let val = match reader.read()? {
-            I32Const { value } => Const::Value(Value::I32(value)),
-            I64Const { value } => Const::Value(Value::I64(value)),
-            F32Const { value } => Const::Value(Value::F32(f32::from_bits(value.bits()))),
-            F64Const { value } => Const::Value(Value::F64(f64::from_bits(value.bits()))),
-            GetGlobal { global_index } => Const::Global(ids.get_global(global_index)?),
+            I32Const { value } => InitExpr::Value(Value::I32(value)),
+            I64Const { value } => InitExpr::Value(Value::I64(value)),
+            F32Const { value } => InitExpr::Value(Value::F32(f32::from_bits(value.bits()))),
+            F64Const { value } => InitExpr::Value(Value::F64(f64::from_bits(value.bits()))),
+            GetGlobal { global_index } => InitExpr::Global(ids.get_global(global_index)?),
             _ => bail!("invalid constant expression"),
         };
         match reader.read()? {
@@ -38,11 +37,11 @@ impl Const {
     }
 }
 
-impl Emit for Const {
+impl Emit for InitExpr {
     fn emit(&self, cx: &mut EmitContext) {
         match *self {
-            Const::Value(val) => val.emit(&mut cx.encoder),
-            Const::Global(id) => {
+            InitExpr::Value(val) => val.emit(&mut cx.encoder),
+            InitExpr::Global(id) => {
                 let idx = cx.indices.get_global_index(id);
                 cx.encoder.byte(0x23); // global.get
                 cx.encoder.u32(idx);

--- a/src/ir/matcher.rs
+++ b/src/ir/matcher.rs
@@ -1,7 +1,7 @@
 //! Matching expressions.
 
 use super::Expr;
-use crate::module::functions::LocalFunction;
+use crate::LocalFunction;
 
 // Re-export the custom derive-generated impls here, where it makes more sense
 // to expose them.

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -8,14 +8,8 @@ pub mod matcher;
 
 use crate::dot::Dot;
 use crate::encode::Encoder;
-use crate::module::data::DataId;
-use crate::module::functions::FunctionId;
-use crate::module::functions::{DisplayExpr, DotExpr};
-use crate::module::globals::GlobalId;
-use crate::module::memories::MemoryId;
-use crate::module::tables::TableId;
-use crate::ty::TypeId;
-use crate::ty::ValType;
+use crate::module::{DisplayExpr, DotExpr};
+use crate::{DataId, FunctionId, GlobalId, MemoryId, TableId, TypeId, ValType};
 use id_arena::Id;
 use std::fmt;
 use std::mem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,22 @@
 #![deny(missing_docs)]
 
 mod arena_set;
-pub mod const_value;
 pub mod dot;
 mod emit;
 mod encode;
-pub mod error;
+mod error;
 mod function_builder;
+mod init_expr;
 pub mod ir;
 mod map;
-pub mod module;
+mod module;
 mod parse;
 pub mod passes;
-pub mod ty;
+mod ty;
 
+pub use crate::error::{ErrorKind, Result};
 pub use crate::function_builder::FunctionBuilder;
+pub use crate::init_expr::InitExpr;
+pub use crate::ir::{Local, LocalId};
+pub use crate::module::*;
+pub use crate::ty::{Type, TypeId, ValType};

--- a/src/module/data.rs
+++ b/src/module/data.rs
@@ -1,13 +1,10 @@
 //! Data segments within a wasm module.
 
-use crate::const_value::Const;
 use crate::emit::{Emit, EmitContext, Section};
-use crate::error::Result;
 use crate::ir::Value;
-use crate::module::Module;
 use crate::parse::IndicesToIds;
 use crate::passes::Used;
-use crate::ty::ValType;
+use crate::{InitExpr, Module, Result, ValType};
 use failure::{bail, ResultExt};
 use id_arena::{Arena, Id};
 
@@ -154,13 +151,13 @@ impl Module {
                     let value = segment.data.to_vec();
                     let memory = self.memories.get_mut(memory);
 
-                    let offset = Const::eval(&init_expr, ids)
+                    let offset = InitExpr::eval(&init_expr, ids)
                         .with_context(|_e| format!("in segment {}", i))?;
                     match offset {
-                        Const::Value(Value::I32(n)) => {
+                        InitExpr::Value(Value::I32(n)) => {
                             memory.data.add_absolute(n as u32, value);
                         }
-                        Const::Global(global) if self.globals.get(global).ty == ValType::I32 => {
+                        InitExpr::Global(global) if self.globals.get(global).ty == ValType::I32 => {
                             memory.data.add_relative(global, value);
                         }
                         _ => bail!("non-i32 constant in segment {}", i),

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -33,7 +33,8 @@ pub struct LocalFunction {
     /// The arena that contains this function's expressions.
     pub(crate) exprs: Arena<Expr>,
 
-    args: Vec<LocalId>,
+    /// Arguments to this function, and the locals that they're assigned to
+    pub args: Vec<LocalId>,
 
     /// The entry block for this function. Always `Some` after the constructor
     /// returns.
@@ -118,6 +119,16 @@ impl LocalFunction {
     /// Get the block associated with the given id.
     pub fn block_mut(&mut self, block: BlockId) -> &mut Block {
         self.exprs[block.into()].unwrap_block_mut()
+    }
+
+    /// Get the expression associated with the given id
+    pub fn get(&self, id: ExprId) -> &Expr {
+        &self.exprs[id]
+    }
+
+    /// Get the expression associated with the given id
+    pub fn get_mut(&mut self, id: ExprId) -> &mut Expr {
+        &mut self.exprs[id]
     }
 
     /// Get the size of this function, in number of expressions.

--- a/src/module/memories.rs
+++ b/src/module/memories.rs
@@ -1,14 +1,10 @@
 //! Memories used in a wasm module.
 
-use crate::const_value::Const;
 use crate::emit::{Emit, EmitContext, Section};
-use crate::error::Result;
 use crate::ir::Value;
-use crate::module::globals::GlobalId;
-use crate::module::imports::ImportId;
-use crate::module::Module;
 use crate::parse::IndicesToIds;
 use crate::passes::Used;
+use crate::{GlobalId, ImportId, InitExpr, Module, Result};
 use id_arena::{Arena, Id};
 
 /// The id of a memory.
@@ -47,17 +43,17 @@ impl Memory {
         self.id
     }
 
-    pub(crate) fn emit_data(&self) -> impl Iterator<Item = (Const, &[u8])> {
+    pub(crate) fn emit_data(&self) -> impl Iterator<Item = (InitExpr, &[u8])> {
         let absolute = self
             .data
             .absolute
             .iter()
-            .map(move |(pos, data)| (Const::Value(Value::I32(*pos as i32)), &data[..]));
+            .map(move |(pos, data)| (InitExpr::Value(Value::I32(*pos as i32)), &data[..]));
         let relative = self
             .data
             .relative
             .iter()
-            .map(move |(id, data)| (Const::Global(*id), &data[..]));
+            .map(move |(id, data)| (InitExpr::Global(*id), &data[..]));
         absolute.chain(relative)
     }
 }
@@ -214,15 +210,15 @@ impl MemoryData {
     }
 
     /// Consumes this data and returns a by-value iterator of each segment
-    pub fn into_iter(self) -> impl Iterator<Item = (Const, Vec<u8>)> {
+    pub fn into_iter(self) -> impl Iterator<Item = (InitExpr, Vec<u8>)> {
         let absolute = self
             .absolute
             .into_iter()
-            .map(move |(pos, data)| (Const::Value(Value::I32(pos as i32)), data));
+            .map(move |(pos, data)| (InitExpr::Value(Value::I32(pos as i32)), data));
         let relative = self
             .relative
             .into_iter()
-            .map(move |(id, data)| (Const::Global(id), data));
+            .map(move |(id, data)| (InitExpr::Global(id), data));
         absolute.chain(relative)
     }
 }

--- a/src/module/tables.rs
+++ b/src/module/tables.rs
@@ -1,12 +1,8 @@
 //! Tables within a wasm module.
 
 use crate::emit::{Emit, EmitContext, Section};
-use crate::error::Result;
-use crate::module::functions::FunctionId;
-use crate::module::globals::GlobalId;
-use crate::module::imports::ImportId;
-use crate::module::Module;
 use crate::parse::IndicesToIds;
+use crate::{FunctionId, GlobalId, ImportId, Module, Result};
 use id_arena::{Arena, Id};
 
 /// The id of a table.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,13 +1,6 @@
-use crate::error::Result;
-use crate::ir::LocalId;
 use crate::map::IdHashMap;
-use crate::module::data::DataId;
-use crate::module::elements::ElementId;
-use crate::module::functions::{Function, FunctionId};
-use crate::module::globals::GlobalId;
-use crate::module::memories::MemoryId;
-use crate::module::tables::TableId;
-use crate::ty::TypeId;
+use crate::{DataId, ElementId, Function, FunctionId, GlobalId, Result};
+use crate::{LocalId, MemoryId, TableId, TypeId};
 use failure::bail;
 
 #[derive(Debug, Default)]
@@ -51,7 +44,7 @@ define_push_get!(push_type, get_type, TypeId, types);
 define_push_get!(push_func, get_func, FunctionId, funcs);
 define_push_get!(push_global, get_global, GlobalId, globals);
 define_push_get!(push_memory, get_memory, MemoryId, memories);
-define_push_get!(push_element, get_element, ElementId, elements);
+//define_push_get!(push_element, get_element, ElementId, elements);
 define_push_get!(push_data, get_data, DataId, data);
 
 impl IndicesToIds {

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -1,16 +1,9 @@
-use crate::const_value::Const;
 use crate::ir::*;
 use crate::map::{IdHashMap, IdHashSet};
-use crate::module::data::{Data, DataId};
-use crate::module::elements::Element;
-use crate::module::exports::{ExportId, ExportItem};
-use crate::module::functions::{Function, FunctionId, FunctionKind, LocalFunction};
-use crate::module::globals::{Global, GlobalId, GlobalKind};
-use crate::module::imports::ImportKind;
-use crate::module::memories::{Memory, MemoryId};
-use crate::module::tables::{Table, TableId, TableKind};
-use crate::module::Module;
-use crate::ty::{Type, TypeId};
+use crate::{Data, DataId, Element, ExportId, ExportItem, Function, InitExpr};
+use crate::{FunctionId, FunctionKind, Global, GlobalId, LocalFunction};
+use crate::{GlobalKind, ImportKind, Memory, MemoryId, Table, TableId};
+use crate::{Module, TableKind, Type, TypeId};
 
 /// Finds the things within a module that are used.
 ///
@@ -134,10 +127,10 @@ impl Used {
             while let Some(t) = stack.globals.pop() {
                 match &module.globals.get(t).kind {
                     GlobalKind::Import(_) => {}
-                    GlobalKind::Local(Const::Global(global)) => {
+                    GlobalKind::Local(InitExpr::Global(global)) => {
                         stack.push_global(*global);
                     }
-                    GlobalKind::Local(Const::Value(_)) => {}
+                    GlobalKind::Local(InitExpr::Value(_)) => {}
                 }
             }
 

--- a/src/passes/validate.rs
+++ b/src/passes/validate.rs
@@ -3,16 +3,10 @@
 //! Currently only does some basic sanity checks, but it's intended that
 //! eventually this is a full typechecking pass!
 
-use crate::const_value::Const;
-use crate::error::Result;
 use crate::ir::*;
-use crate::module::data::DataId;
-use crate::module::functions::{Function, FunctionKind, LocalFunction};
-use crate::module::globals::{Global, GlobalKind};
-use crate::module::memories::{Memory, MemoryId};
-use crate::module::tables::{Table, TableKind};
-use crate::module::Module;
-use crate::ty::ValType;
+use crate::ValType;
+use crate::{DataId, Function, FunctionKind, InitExpr, LocalFunction, Result};
+use crate::{Global, GlobalKind, Memory, MemoryId, Module, Table, TableKind};
 use failure::{bail, ResultExt};
 use rayon::prelude::*;
 use std::collections::HashSet;
@@ -139,10 +133,10 @@ fn validate_exports(module: &Module) -> Result<()> {
 fn validate_global(module: &Module, global: &Global) -> Result<()> {
     match global.kind {
         GlobalKind::Import(_) => return Ok(()),
-        GlobalKind::Local(Const::Value(value)) => {
+        GlobalKind::Local(InitExpr::Value(value)) => {
             validate_value(value, global.ty).context("invalid type on global")?;
         }
-        GlobalKind::Local(Const::Global(other)) => {
+        GlobalKind::Local(InitExpr::Global(other)) => {
             let other = module.globals.get(other);
             match other.kind {
                 GlobalKind::Import(_) => {}


### PR DESCRIPTION
This commit reorganizes the crate to dump almost everything into the
global namespace. The `ir` submodule remains, but all other submodules
are now hidden from the public API. All types, however, should be
accessible from either the root of the crate or the `ir` submodule.

This also additionally renames `Const` to `InitExpr` as it's not
actually constant, it's used as an initialization expression.