### PR TITLE
Add an option to skip validation after parsing

### DIFF
--- a/src/module/config.rs
+++ b/src/module/config.rs
@@ -5,6 +5,7 @@ use crate::module::Module;
 #[derive(Clone, Debug, Default)]
 pub struct ModuleConfig {
     pub(crate) generate_names: bool,
+    pub(crate) skip_strict_validate: bool,
 }
 
 impl ModuleConfig {
@@ -20,6 +21,20 @@ impl ModuleConfig {
     /// if enabled!
     pub fn generate_names(&mut self, generate: bool) -> &mut ModuleConfig {
         self.generate_names = generate;
+        self
+    }
+
+    /// Indicates whether the module, after parsing, performs strict validation
+    /// of the wasm module to adhere with the current version of the wasm
+    /// specification.
+    ///
+    /// This can be expensive for some modules and strictly isn't required to
+    /// create a `Module` from a wasm file. This includes checks such as "atomic
+    /// instructions require a shared memory".
+    ///
+    /// By default this flag is `true`
+    pub fn strict_validate(&mut self, strict: bool) -> &mut ModuleConfig {
+        self.skip_strict_validate = !strict;
         self
     }
 

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -205,7 +205,9 @@ impl Module {
             .add_processed_by("walrus", env!("CARGO_PKG_VERSION"));
 
         // TODO: probably run this in a different location
-        crate::passes::validate::run(&ret)?;
+        if !ret.config.skip_strict_validate {
+            crate::passes::validate::run(&ret)?;
+        }
 
         log::debug!("parse complete");
         Ok(ret)


### PR DESCRIPTION
We'll at least need this for parsing LLVM's output which currently has
atomic instructions but doesn't have shared memory!