### PR TITLE
Don't use stack recursion when parsing instructions

### DIFF
--- a/src/module/exports.rs
+++ b/src/module/exports.rs
@@ -1,9 +1,9 @@
 //! Exported items in a wasm module.
 
-use crate::{GlobalId, MemoryId, FunctionId, TableId, Module, Result};
-use crate::map::IdHashSet;
 use crate::emit::{Emit, EmitContext, Section};
+use crate::map::IdHashSet;
 use crate::parse::IndicesToIds;
+use crate::{FunctionId, GlobalId, MemoryId, Module, Result, TableId};
 use id_arena::{Arena, Id};
 
 /// The id of an export.

--- a/src/module/functions/local_function/context.rs
+++ b/src/module/functions/local_function/context.rs
@@ -59,6 +59,16 @@ pub struct FunctionContext<'a> {
 
     /// The control frames stack.
     pub controls: &'a mut ControlStack,
+
+    /// If we're currently parsing an if/else expression, where we're at
+    pub if_else: Vec<IfElseState>,
+}
+
+#[derive(Debug)]
+pub struct IfElseState {
+    pub condition: ExprId,
+    pub consequent: BlockId,
+    pub alternative: Option<BlockId>,
 }
 
 impl<'a> FunctionContext<'a> {
@@ -78,6 +88,7 @@ impl<'a> FunctionContext<'a> {
             func,
             operands,
             controls,
+            if_else: Vec::new(),
         }
     }
 

--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -4,7 +4,7 @@ use crate::emit::{Emit, EmitContext, Section};
 use crate::parse::IndicesToIds;
 use crate::{FunctionId, FunctionTable, GlobalId, MemoryId, Result, TableId};
 use crate::{Module, TableKind, TypeId, ValType};
-use id_arena::{Id, Arena};
+use id_arena::{Arena, Id};
 
 /// The id of an import.
 pub type ImportId = Id<Import>;


### PR DESCRIPTION
When integrating `walrus` into `wasm-bindgen` everything looked to be
all ship shape except that in debug mode `wasm-bindgen` would very
quickly blow the stack when parsing pretty reasonable wasm files (not
like clang, but like a few test suites). This was due to instruction
validation being stack-recursive and allocating pretty big stack frames
in debug mode.

While the problems didn't show up during release mode at all, I figured
it'd be good to try to tackle this problem to make development of
`wasm-bindgen` a bit easier. To that end this commit updates the
`validate_instruction` function to not recursively call itself, but
rather it's simply called in a loop now. Overall this ended up being a
pretty nice simplification for everything except if/else!