### PR TITLE
Expose a `FunctionBuilder` through `LocalFunction`

### DIFF
--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -752,7 +752,7 @@ fn create_matchers(variants: &[WalrusVariant]) -> impl quote::ToTokens {
                                 true #(
                                     && #self_args.is_match(
                                         local_func,
-                                        &local_func.exprs[*#args]
+                                        local_func.get(*#args)
                                     )
                                 )*
                             }

--- a/src/function_builder.rs
+++ b/src/function_builder.rs
@@ -8,7 +8,7 @@ use std::ops::{Deref, DerefMut, Drop};
 /// A helpful struct used for building instances of `LocalFunction`
 #[derive(Default, Debug)]
 pub struct FunctionBuilder {
-    arena: Arena<Expr>,
+    pub(crate) arena: Arena<Expr>,
 }
 
 impl FunctionBuilder {
@@ -141,7 +141,7 @@ impl FunctionBuilder {
             results: ty.results().to_vec().into_boxed_slice(),
             exprs,
         });
-        let func = LocalFunction::new(ty_id, args, self.arena, entry);
+        let func = LocalFunction::new(ty_id, args, self, entry);
         funcs.add_local(func)
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -992,7 +992,7 @@ impl<'expr> Visit<'expr> for ExprId {
     where
         V: Visitor<'expr>,
     {
-        visitor.visit_expr(&visitor.local_function().exprs[*self])
+        visitor.visit_expr(&visitor.local_function().get(*self))
     }
 }
 
@@ -1006,11 +1006,11 @@ impl VisitMut for ExprId {
         // use graph traversal instead of a simple tree walk like we have today
         // when that comes about.
         let mut expr = mem::replace(
-            &mut visitor.local_function_mut().exprs[*self],
+            visitor.local_function_mut().get_mut(*self),
             Expr::Unreachable(Unreachable {}),
         );
         visitor.visit_expr_mut(&mut expr);
-        visitor.local_function_mut().exprs[*self] = expr;
+        *visitor.local_function_mut().get_mut(*self) = expr;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod passes;
 mod ty;
 
 pub use crate::error::{ErrorKind, Result};
-pub use crate::function_builder::FunctionBuilder;
+pub use crate::function_builder::{FunctionBuilder, BlockBuilder};
 pub use crate::init_expr::InitExpr;
 pub use crate::ir::{Local, LocalId};
 pub use crate::module::*;

--- a/src/module/functions/local_function/context.rs
+++ b/src/module/functions/local_function/context.rs
@@ -170,7 +170,7 @@ impl<'a> FunctionContext<'a> {
                 }
             }
 
-            let block = self.func.exprs[frame.block.into()].unwrap_block_mut();
+            let block = self.func.block_mut(frame.block);
             block.exprs.extend(extra_exprs);
             block.exprs.push(expr);
         }
@@ -192,8 +192,7 @@ impl<'a> FunctionContext<'a> {
     where
         E: Into<ExprId>,
     {
-        let block = self.func.exprs[block.into()].unwrap_block_mut();
-        block.exprs.push(expr.into());
+        self.func.block_mut(block).exprs.push(expr.into());
     }
 
     pub fn add_to_frame_block<E>(&mut self, control_frame: usize, expr: E)
@@ -228,8 +227,8 @@ impl<'a> FunctionContext<'a> {
 
     pub fn add_side_effect(&mut self, value: ExprId, side_effect: ExprId) -> ExprId {
         // If we can add it to an existing `WithSideEffects` expr for this value, then do that.
-        if let Some(Expr::WithSideEffects(WithSideEffects { after, .. })) =
-            self.func.exprs.get_mut(value)
+        if let Expr::WithSideEffects(WithSideEffects { after, .. }) =
+            self.func.get_mut(value)
         {
             after.push(side_effect);
             return value;

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -56,7 +56,7 @@ impl Emit<'_, '_> {
         let old = self.id;
         self.id = id;
 
-        match &self.func.exprs[id] {
+        match &self.func.get(id) {
             Const(e) => e.value.emit(self.encoder),
             Block(e) => self.visit_block(e),
             BrTable(e) => self.visit_br_table(e),


### PR DESCRIPTION
This should allow to continue to build expressions for a function even
after it exists