### PR TITLE
Add before effects with `WithSideEffects`

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -483,10 +483,12 @@ pub enum Expr {
     ///   (call $f))
     /// ```
     WithSideEffects {
+        /// The stack-neutral, side-effecting operations before `value`
+        before: Vec<ExprId>,
         /// The value.
         value: ExprId,
-        /// The stack-neutral, side-effecting operations.
-        side_effects: Vec<ExprId>,
+        /// The stack-neutral, side-effecting operations after `value`
+        after: Vec<ExprId>,
     },
 }
 

--- a/src/module/functions/local_function/context.rs
+++ b/src/module/functions/local_function/context.rs
@@ -228,18 +228,19 @@ impl<'a> FunctionContext<'a> {
 
     pub fn add_side_effect(&mut self, value: ExprId, side_effect: ExprId) -> ExprId {
         // If we can add it to an existing `WithSideEffects` expr for this value, then do that.
-        if let Some(Expr::WithSideEffects(WithSideEffects { side_effects, .. })) =
+        if let Some(Expr::WithSideEffects(WithSideEffects { after, .. })) =
             self.func.exprs.get_mut(value)
         {
-            side_effects.push(side_effect);
+            after.push(side_effect);
             return value;
         }
 
         // Otherwise, allocate a new `WithSideEffects`.
         self.func
             .alloc(WithSideEffects {
+                before: Vec::new(),
                 value,
-                side_effects: vec![side_effect],
+                after: vec![side_effect],
             })
             .into()
     }

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -75,8 +75,11 @@ impl Emit<'_, '_> {
             }
 
             WithSideEffects(e) => {
+                for x in e.before.iter() {
+                    self.visit(*x);
+                }
                 self.visit(e.value);
-                for x in e.side_effects.iter() {
+                for x in e.after.iter() {
                     self.visit(*x);
                 }
             }


### PR DESCRIPTION
This should allow us to emit arbitrary stack-neutral items at any time
within a block by using these nodes, whether or not the side-effectful
parts happen either before or after.