### PR TITLE
Add a convenience for getting the function tables

### DIFF
--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -56,7 +56,7 @@ impl Emit<'_, '_> {
         let old = self.id;
         self.id = id;
 
-        match &self.func.get(id) {
+        match self.func.get(id) {
             Const(e) => e.value.emit(self.encoder),
             Block(e) => self.visit_block(e),
             BrTable(e) => self.visit_br_table(e),

--- a/src/module/functions/mod.rs
+++ b/src/module/functions/mod.rs
@@ -424,6 +424,7 @@ impl Emit for ModuleFunctions {
         let bytes = functions
             .into_par_iter()
             .map(|(id, func, _size)| {
+                log::debug!("emit function {:?} {:?}", id, cx.module.funcs.get(id).name);
                 let mut wasm = Vec::new();
                 let mut encoder = Encoder::new(&mut wasm);
                 let local_indices = func.emit_locals(id, cx.module, cx.used, &mut encoder);


### PR DESCRIPTION
If applicable modules typically have one function table when coming from
languages like C or Rust, so add a convenience function that returns the
function table if it's present.