### PR TITLE
Add an explicit GC pass to walrus

### DIFF
--- a/crates/tests/tests/round_trip.rs
+++ b/crates/tests/tests/round_trip.rs
@@ -6,7 +6,7 @@ use walrus_tests_utils::{wasm2wat, wat2wasm};
 
 fn run(wat_path: &Path) -> Result<(), failure::Error> {
     let wasm = wat2wasm(wat_path);
-    let module = walrus::Module::from_buffer(&wasm)?;
+    let mut module = walrus::Module::from_buffer(&wasm)?;
 
     if env::var("WALRUS_TESTS_DOT").is_ok() {
         for (i, func) in module.functions().enumerate() {
@@ -17,6 +17,7 @@ fn run(wat_path: &Path) -> Result<(), failure::Error> {
     }
 
     let out_wasm_file = wat_path.with_extension("out.wasm");
+    walrus::passes::gc::run(&mut module);
     module.emit_wasm_file(&out_wasm_file)?;
 
     let out_wat = wasm2wat(&out_wasm_file);

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -4,8 +4,7 @@
 
 use crate::encode::{Encoder, MAX_U32_LENGTH};
 use crate::ir::Local;
-use crate::map::IdHashMap;
-use crate::passes::Used;
+use crate::map::{IdHashMap, IdHashSet};
 use crate::{Data, DataId, Element, ElementId, Function, FunctionId};
 use crate::{Global, GlobalId, Memory, MemoryId, Module, Table, TableId};
 use crate::{Type, TypeId};
@@ -13,9 +12,9 @@ use std::ops::{Deref, DerefMut};
 
 pub struct EmitContext<'a> {
     pub module: &'a Module,
-    pub used: &'a Used,
     pub indices: &'a mut IdsToIndices,
     pub encoder: Encoder<'a>,
+    pub locals: IdHashMap<Function, IdHashSet<Local>>,
 }
 
 pub struct SubContext<'a, 'cx> {

--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -205,28 +205,15 @@ impl Module {
 impl Emit for ModuleImports {
     fn emit(&self, cx: &mut EmitContext) {
         log::debug!("emit import section");
-        let mut imports = Vec::new();
-
-        for (_id, import) in self.arena.iter() {
-            let used = match import.kind {
-                ImportKind::Function(id) => cx.used.funcs.contains(&id),
-                ImportKind::Global(id) => cx.used.globals.contains(&id),
-                ImportKind::Memory(id) => cx.used.memories.contains(&id),
-                ImportKind::Table(id) => cx.used.tables.contains(&id),
-            };
-            if !used {
-                continue;
-            }
-            imports.push(import);
-        }
-        if imports.len() == 0 {
+        let count = self.iter().count();
+        if count == 0 {
             return;
         }
 
         let mut cx = cx.start_section(Section::Import);
-        cx.encoder.usize(imports.len());
+        cx.encoder.usize(count);
 
-        for import in imports {
+        for import in self.iter() {
             cx.encoder.str(&import.module);
             cx.encoder.str(&import.name);
             match import.kind {

--- a/src/module/tables.rs
+++ b/src/module/tables.rs
@@ -200,7 +200,7 @@ impl Module {
 impl Emit for ModuleTables {
     fn emit(&self, cx: &mut EmitContext) {
         log::debug!("emit table section");
-        // Skip imported tables because those are emitted elsewhere
+        // Skip imported tables because those are emitted in the import section.
         let tables = self.iter().filter(|t| t.import.is_none()).count();
         if tables == 0 {
             return;

--- a/src/module/tables.rs
+++ b/src/module/tables.rs
@@ -200,28 +200,17 @@ impl Module {
 impl Emit for ModuleTables {
     fn emit(&self, cx: &mut EmitContext) {
         log::debug!("emit table section");
-        let emitted = |cx: &EmitContext, table: &Table| {
-            // If it's imported we already emitted this in the import section
-            cx.used.tables.contains(&table.id) && table.import.is_none()
-        };
-
-        let tables = self
-            .arena
-            .iter()
-            .filter(|(_id, table)| emitted(cx, table))
-            .count();
-
+        // Skip imported tables because those are emitted elsewhere
+        let tables = self.iter().filter(|t| t.import.is_none()).count();
         if tables == 0 {
             return;
         }
 
         let mut cx = cx.start_section(Section::Table);
         cx.encoder.usize(tables);
-        for (id, table) in self.arena.iter() {
-            if emitted(&cx, table) {
-                cx.indices.push_table(id);
-                table.emit(&mut cx);
-            }
+        for table in self.iter().filter(|t| t.import.is_none()) {
+            cx.indices.push_table(table.id());
+            table.emit(&mut cx);
         }
     }
 }

--- a/src/module/types.rs
+++ b/src/module/types.rs
@@ -29,7 +29,11 @@ impl ModuleTypes {
         self.arena.iter().map(|(_, f)| f)
     }
 
-    /// Delete a type from this module
+    /// Removes a type from this module.
+    ///
+    /// It is up to you to ensure that any potential references to the deleted
+    /// type are also removed, eg `call_indirect` expressions, function types,
+    /// etc.
     pub fn delete(&mut self, ty: TypeId) {
         self.arena.remove(ty);
     }

--- a/src/module/types.rs
+++ b/src/module/types.rs
@@ -29,6 +29,11 @@ impl ModuleTypes {
         self.arena.iter().map(|(_, f)| f)
     }
 
+    /// Delete a type from this module
+    pub fn delete(&mut self, ty: TypeId) {
+        self.arena.remove(ty);
+    }
+
     /// Add a new type to this module, and return its `Id`
     pub fn add(&mut self, params: &[ValType], results: &[ValType]) -> TypeId {
         let id = self.arena.next_id();
@@ -74,7 +79,7 @@ impl Module {
 impl Emit for ModuleTypes {
     fn emit(&self, cx: &mut EmitContext) {
         log::debug!("emitting type section");
-        let ntypes = cx.used.types.len();
+        let ntypes = self.iter().count();
         if ntypes == 0 {
             return;
         }
@@ -82,9 +87,6 @@ impl Emit for ModuleTypes {
         cx.encoder.usize(ntypes);
 
         for (id, ty) in self.arena.iter() {
-            if !cx.used.types.contains(&id) {
-                continue;
-            }
             cx.indices.push_type(id);
             ty.emit(&mut cx);
         }

--- a/src/passes/gc.rs
+++ b/src/passes/gc.rs
@@ -1,0 +1,62 @@
+//! Removes any non-referenced items from a module
+//!
+//! This commit will remove functions, data, etc, that are not referenced
+//! internally and can be safely removed.
+
+use crate::map::IdHashSet;
+use crate::passes::Used;
+use crate::{ImportKind, Module};
+use id_arena::Id;
+
+/// Run GC passes over the module specified.
+pub fn run(m: &mut Module) {
+    let used = Used::new(m, m.exports.iter().map(|e| e.id()));
+
+    let mut unused_imports = Vec::new();
+    for import in m.imports.iter() {
+        let used = match &import.kind {
+            ImportKind::Function(f) => used.funcs.contains(f),
+            ImportKind::Table(t) => used.tables.contains(t),
+            ImportKind::Global(g) => used.globals.contains(g),
+            ImportKind::Memory(m) => used.memories.contains(m),
+        };
+        if !used {
+            unused_imports.push(import.id());
+        }
+    }
+    for id in unused_imports {
+        m.imports.delete(id);
+    }
+
+    for id in unused(&used.tables, m.tables.iter().map(|t| t.id())) {
+        m.tables.delete(id);
+    }
+    for id in unused(&used.globals, m.globals.iter().map(|t| t.id())) {
+        m.globals.delete(id);
+    }
+    for id in unused(&used.memories, m.memories.iter().map(|t| t.id())) {
+        m.memories.delete(id);
+    }
+    for id in unused(&used.data, m.data.iter().map(|t| t.id())) {
+        m.data.delete(id);
+    }
+    for id in unused(&used.elements, m.elements.iter().map(|t| t.id())) {
+        m.elements.delete(id);
+    }
+    for id in unused(&used.types, m.types.iter().map(|t| t.id())) {
+        m.types.delete(id);
+    }
+    for id in unused(&used.funcs, m.funcs.iter().map(|t| t.id())) {
+        m.funcs.delete(id);
+    }
+}
+
+fn unused<T>(used: &IdHashSet<T>, all: impl Iterator<Item = Id<T>>) -> Vec<Id<T>> {
+    let mut unused = Vec::new();
+    for id in all {
+        if !used.contains(&id) {
+            unused.push(id);
+        }
+    }
+    unused
+}

--- a/src/passes/mod.rs
+++ b/src/passes/mod.rs
@@ -1,5 +1,6 @@
 //! Passes over whole modules or individual functions.
 
+pub mod gc;
 mod used;
-pub use self::used::Used;
 pub mod validate;
+pub use self::used::Used;

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -1,5 +1,5 @@
 use crate::ir::*;
-use crate::map::{IdHashMap, IdHashSet};
+use crate::map::IdHashSet;
 use crate::{Data, DataId, Element, ExportId, ExportItem, Function, InitExpr};
 use crate::{FunctionId, FunctionKind, Global, GlobalId, LocalFunction};
 use crate::{GlobalKind, ImportKind, Memory, MemoryId, Table, TableId};
@@ -26,8 +26,6 @@ pub struct Used {
     pub elements: IdHashSet<Element>,
     /// The module's used passive data segments.
     pub data: IdHashSet<Data>,
-    /// Locals used within functions
-    pub locals: IdHashMap<Function, IdHashSet<Local>>,
 }
 
 impl Used {
@@ -99,7 +97,6 @@ impl Used {
                         func.entry_block().visit(&mut UsedVisitor {
                             func,
                             stack: &mut stack,
-                            id: f,
                         });
                     }
                     FunctionKind::Import(_) => {}
@@ -184,7 +181,6 @@ impl UsedStack<'_> {
 struct UsedVisitor<'a, 'b> {
     func: &'a LocalFunction,
     stack: &'a mut UsedStack<'b>,
-    id: FunctionId,
 }
 
 impl<'expr> Visitor<'expr> for UsedVisitor<'expr, '_> {
@@ -214,14 +210,5 @@ impl<'expr> Visitor<'expr> for UsedVisitor<'expr, '_> {
 
     fn visit_data_id(&mut self, &t: &DataId) {
         self.stack.used.data.insert(t);
-    }
-
-    fn visit_local_id(&mut self, &l: &LocalId) {
-        self.stack
-            .used
-            .locals
-            .entry(self.id)
-            .or_insert_with(IdHashSet::default)
-            .insert(l);
     }
 }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -3,6 +3,7 @@
 use crate::emit::{Emit, EmitContext};
 use crate::encode::Encoder;
 use crate::error::Result;
+use crate::tombstone_arena::Tombstone;
 use id_arena::Id;
 use std::fmt;
 use std::hash;
@@ -34,6 +35,13 @@ impl hash::Hash for Type {
         // Do not hash id.
         self.params.hash(h);
         self.results.hash(h)
+    }
+}
+
+impl Tombstone for Type {
+    fn on_delete(&mut self) {
+        self.params = Box::new([]);
+        self.results = Box::new([]);
     }
 }
 


### PR DESCRIPTION
Currently we implicity GC a module when emitting it, but this instead
adds an explicit GC step with the new `delete` functions that we have
now. This way consumers can explicitly choose when to `gc` and then act
on the decisions of the GC to emit different bindings, for example.