### PR TITLE
Update encoding of `table.grow`

### DIFF
--- a/crates/tests/tests/round_trip/anyref4.wat
+++ b/crates/tests/tests/round_trip/anyref4.wat
@@ -21,13 +21,13 @@
     table.get 1
     table.set 0
 
-    i32.const 0
     ref.null
+    i32.const 0
     table.grow 0
     drop
 
-    i32.const 0
     ref.null
+    i32.const 0
     table.grow 1
     drop
 
@@ -64,12 +64,12 @@
       i32.const 0
       table.get 1
       table.set 0
-      i32.const 0
       ref.null
+      i32.const 0
       table.grow 0
       drop
-      i32.const 0
       ref.null
+      i32.const 0
       table.grow 1
       drop
       ref.null

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -746,8 +746,8 @@ impl Emit<'_, '_> {
                 self.encoder.u32(idx);
             }
             TableGrow(e) => {
-                self.visit(e.amount);
                 self.visit(e.value);
+                self.visit(e.amount);
                 self.encoder.raw(&[0xfc, 0x0f]);
                 let idx = self.indices.get_table_index(e.table);
                 self.encoder.u32(idx);

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -1276,8 +1276,8 @@ fn validate_instruction(ctx: &mut ValidationContext, inst: Operator) -> Result<(
                 TableKind::Anyref(_) => Anyref,
                 TableKind::Function(_) => bail!("cannot grow function table yet"),
             };
-            let (_, value) = ctx.pop_operand_expected(Some(expected_ty))?;
             let (_, amount) = ctx.pop_operand_expected(Some(I32))?;
+            let (_, value) = ctx.pop_operand_expected(Some(expected_ty))?;
             let expr = ctx.func.alloc(TableGrow {
                 table,
                 amount,


### PR DESCRIPTION
Looks like the order of its operands have swapped since this was last
tested!