### PR TITLE
Added a find Import Id by module and name method to ModuleImports

### DIFF
--- a/crates/tests/build.rs
+++ b/crates/tests/build.rs
@@ -57,4 +57,5 @@ fn main() {
     generate_tests("round_trip");
     generate_tests("ir");
     generate_tests("spec-tests");
+    generate_tests("function_imports");
 }

--- a/crates/tests/tests/function_imports.rs
+++ b/crates/tests/tests/function_imports.rs
@@ -1,0 +1,17 @@
+use std::path::Path;
+use walrus_tests_utils::{wat2wasm};
+
+fn run(wat_path: &Path) -> Result<(), failure::Error> {
+    let wasm = wat2wasm(wat_path);
+    let module = walrus::Module::from_buffer(&wasm)?;
+
+    assert!(module.imports.find("doggo", "husky").is_some());
+    assert!(module.imports.find("doggo", "shepherd").is_some());
+    assert!(module.imports.find("doggo", "siamese").is_none());
+    assert!(module.imports.find("snek", "cobra").is_none());
+    assert!(module.imports.find("cat", "siamese").is_some());
+
+    Ok(())
+}
+
+include!(concat!(env!("OUT_DIR"), "/function_imports.rs"));

--- a/crates/tests/tests/function_imports/pets_function_imports.wat
+++ b/crates/tests/tests/function_imports/pets_function_imports.wat
@@ -1,0 +1,7 @@
+(module
+  (type (func))
+  (import "doggo" "husky" (func (type 0)))
+  (import "doggo" "shepherd" (func (type 0)))
+  (import "cat" "siamese" (func (type 0)))
+  (export "b" (func 0))
+)

--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -92,6 +92,15 @@ impl ModuleImports {
             kind: kind.into(),
         })
     }
+
+    /// Get the import with the given module and name
+    pub fn find(&self, module: &str, name: &str) -> Option<ImportId> {
+        let import = self.arena
+            .iter()
+            .find(|(_, import)| import.name == name && import.module == module);
+
+        Some(import?.0)
+    }
 }
 
 impl Module {


### PR DESCRIPTION
This simply adds a method to get an import's id by module/name pair. #84 