### PR TITLE
Fuzzing with `wasm-opt -ttf`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ after_script:
   - sccache -s
 
 install:
+  # Build WABT
   - git clone --recursive https://github.com/WebAssembly/wabt.git
   - mkdir wabt/build
   - cd wabt/build
@@ -20,6 +21,15 @@ install:
   - export PATH=$PATH:$(pwd)/wabt/build
   - which wasm2wat
   - which wat2wasm
+  # Build binaryen
+  - git clone --recursive https://github.com/WebAssembly/binaryen.git
+  - mkdir binaryen/build
+  - cd binaryen/build
+  - cmake .. -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+  - make -j 8
+  - cd -
+  - export PATH=$PATH:$(pwd)/binaryen/build/bin
+  - which wasm-opt
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,12 @@ matrix:
     - name: "test (nightly)"
       rust: nightly
 
+    # A job to run our fuzzers a bit longer than the default.
+    - name: "fuzz (stable)"
+      rust: stable
+      script:
+        - WALRUS_FUZZ_TIMEOUT=$((60 * 5)) cargo test -p walrus-fuzz
+
     - name: "check benches"
       rust: stable
       script:

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 rand = "0.6"
 tempfile = "3.0.5"
+failure = "0.1.5"
 
 [dependencies.walrus]
 path = "../.."

--- a/crates/fuzz/src/lib.rs
+++ b/crates/fuzz/src/lib.rs
@@ -2,27 +2,43 @@
 
 #![deny(missing_docs)]
 
+use failure::ResultExt;
 use rand::{Rng, SeedableRng};
 use std::cmp;
 use std::fmt;
 use std::fs;
+use std::marker::PhantomData;
 use std::path::Path;
 use std::time;
 use walrus_tests_utils::{wasm_interp, wat2wasm};
+
+/// `Ok(T)` or a `Err(failure::Error)`
+pub type Result<T> = std::result::Result<T, failure::Error>;
 
 #[derive(Copy, Clone, Debug)]
 enum ValType {
     I32,
 }
 
+/// Anything that can generate WAT test cases for fuzzing.
+pub trait TestCaseGenerator {
+    /// The name of this test case generator.
+    const NAME: &'static str;
+
+    /// Generate a string of WAT deterministically using the given RNG seed and
+    /// fuel.
+    fn generate(seed: u64, fuel: usize) -> String;
+}
+
 /// Configuration for fuzzing.
-pub struct Config {
+pub struct Config<G: TestCaseGenerator> {
+    _generator: PhantomData<G>,
     fuel: usize,
     timeout: u64,
     scratch: tempfile::NamedTempFile,
 }
 
-impl Config {
+impl<G: TestCaseGenerator> Config<G> {
     /// The default fuel level.
     pub const DEFAULT_FUEL: usize = 64;
 
@@ -30,7 +46,7 @@ impl Config {
     pub const DEFAULT_TIMEOUT_SECS: u64 = 5;
 
     /// Construct a new fuzzing configuration.
-    pub fn new() -> Config {
+    pub fn new() -> Config<G> {
         let fuel = Self::DEFAULT_FUEL;
         let timeout = Self::DEFAULT_TIMEOUT_SECS;
 
@@ -42,6 +58,7 @@ impl Config {
         let scratch = tempfile::NamedTempFile::new_in(dir).unwrap();
 
         Config {
+            _generator: PhantomData,
             fuel,
             timeout,
             scratch,
@@ -51,81 +68,103 @@ impl Config {
     /// Set the fuel level.
     ///
     /// `fuel` must be greater than zero.
-    pub fn set_fuel(mut self, fuel: usize) -> Config {
+    pub fn set_fuel(mut self, fuel: usize) -> Config<G> {
         assert!(fuel > 0);
         self.fuel = fuel;
         self
     }
 
     fn gen_wat(&self, seed: u64) -> String {
-        WatGen::generate(rand::rngs::SmallRng::seed_from_u64(seed), self.fuel)
+        G::generate(seed, self.fuel)
     }
 
-    fn wat2wasm(&self, wat: &str) -> Vec<u8> {
-        fs::write(self.scratch.path(), wat).unwrap();
+    fn wat2wasm(&self, wat: &str) -> Result<Vec<u8>> {
+        fs::write(self.scratch.path(), wat).context("failed to write to scratch file")?;
         wat2wasm(self.scratch.path())
     }
 
-    fn interp(&self, wasm: &[u8]) -> String {
-        fs::write(self.scratch.path(), &wasm).unwrap();
+    fn interp(&self, wasm: &[u8]) -> Result<String> {
+        fs::write(self.scratch.path(), &wasm).context("failed to write to scratch file")?;
         wasm_interp(self.scratch.path())
     }
 
-    fn round_trip_through_walrus(&self, wasm: &[u8]) -> Vec<u8> {
-        walrus::Module::from_buffer(&wasm)
-            .unwrap()
+    fn round_trip_through_walrus(&self, wasm: &[u8]) -> Result<Vec<u8>> {
+        println!("parsing into walrus::Module");
+        let module =
+            walrus::Module::from_buffer(&wasm).context("walrus failed to parse the wasm buffer")?;
+        println!("serializing walrus::Module back into wasm");
+        let buf = module
             .emit_wasm()
-            .unwrap()
+            .context("walrus failed to serialize a module to wasm")?;
+        Ok(buf)
     }
 
-    fn run_one(&self, wat: &str) -> Option<FailingTestCase> {
-        let wasm = self.wat2wasm(&wat);
-        let expected = self.interp(&wasm);
+    fn run_one(&self, wat: &str) -> Result<()> {
+        let wasm = self.wat2wasm(&wat)?;
+        let expected = self.interp(&wasm)?;
 
-        let walrus_wasm = self.round_trip_through_walrus(&wasm);
-        let actual = self.interp(&walrus_wasm);
+        let walrus_wasm = self.round_trip_through_walrus(&wasm)?;
+        let actual = self.interp(&walrus_wasm)?;
 
         if expected == actual {
-            return None;
+            return Ok(());
         }
 
-        Some(FailingTestCase {
+        Err(FailingTestCase {
+            generator: G::NAME,
             wat: wat.to_string(),
             expected,
             actual,
-        })
+        }
+        .into())
     }
 
     /// Generate a wasm file and then compare its output in the reference
     /// interpreter before and after round tripping it through `walrus`.
     ///
     /// Returns the reduced failing test case, if any.
-    pub fn run(&mut self) -> Option<FailingTestCase> {
+    pub fn run(&mut self) -> Result<()> {
         let start = time::Instant::now();
         let timeout = time::Duration::from_secs(self.timeout);
         let mut seed = rand::thread_rng().gen();
-        let mut failing = None;
+        let mut failing = Ok(());
         loop {
+            println!("-----------------------------------------------------");
+
             let wat = self.gen_wat(seed);
-            match self.run_one(&wat) {
-                // We reduced fuel as far as we could, so return the last
-                // failing test case.
-                None if failing.is_some() => return failing,
-                // Used all of our time, and didn't find any failing test cases.
-                None if time::Instant::now().duration_since(start) > timeout => return None,
-                // This RNG seed did not produce a failing test case, so choose
-                // a new one.
-                None => {
+            match self
+                .run_one(&wat)
+                .with_context(|_| format!("wat = {}", wat))
+            {
+                Ok(()) => {
+                    // We reduced fuel as far as we could, so return the last
+                    // failing test case.
+                    if failing.is_err() {
+                        return failing;
+                    }
+
+                    // Used all of our time, and didn't find any failing test cases.
+                    if time::Instant::now().duration_since(start) > timeout {
+                        assert!(failing.is_ok());
+                        return Ok(());
+                    }
+
+                    // This RNG seed did not produce a failing test case, so choose
+                    // a new one.
                     seed = rand::thread_rng().gen();
+                    continue;
                 }
-                Some(f) => {
-                    failing = Some(f);
+
+                Err(e) => {
+                    let e: failure::Error = e.into();
+                    print_err(&e);
+                    failing = Err(e);
 
                     // If we can try and reduce this test case with another
                     // iteration but with smaller fuel, do that. Otherwise
                     // return the failing test case.
                     if self.fuel > 1 {
-                        self.fuel /= 2;
+                        self.fuel -= self.fuel / 10;
                     } else {
                         return failing;
                     }
@@ -149,6 +188,9 @@ pub struct FailingTestCase {
     /// The reference interpeter's output while interpreting the wasm *after* it
     /// has been round tripped through `walrus`.
     pub actual: String,
+
+    /// The test case generator that created this failing test case.
+    pub generator: &'static str,
 }
 
 impl fmt::Display for FailingTestCase {
@@ -173,36 +215,40 @@ Here is a standalone test case:
 ----------------8<----------------8<----------------8<----------------
 #[test]
 fn test_name() {{
-    walrus_fuzz::assert_round_trip_execution_is_same(\"\\
+    walrus_fuzz::assert_round_trip_execution_is_same::<{generator}>(\"\\
 {wat}\");
 }}
 ----------------8<----------------8<----------------8<----------------
 ",
             wat = self.wat,
             before = self.expected,
-            after = self.actual
+            after = self.actual,
+            generator = self.generator,
         )
     }
 }
 
+impl std::error::Error for FailingTestCase {}
+
 /// Assert that the given WAT has the same execution trace before and after
 /// round tripping it through walrus.
-pub fn assert_round_trip_execution_is_same(wat: &str) {
-    let config = Config::new();
+pub fn assert_round_trip_execution_is_same<G: TestCaseGenerator>(wat: &str) {
+    let config = Config::<G>::new();
     let failing_test_case = config.run_one(wat);
-    assert!(failing_test_case.is_none());
+    assert!(failing_test_case.is_ok());
 }
 
-struct WatGen<R> {
-    rng: R,
+/// A simple WAT generator.
+pub struct WatGen {
+    rng: rand::rngs::SmallRng,
     wat: String,
 }
 
-impl<R> WatGen<R>
-where
-    R: Rng,
-{
-    fn generate(rng: R, fuel: usize) -> String {
+impl TestCaseGenerator for WatGen {
+    const NAME: &'static str = "WatGen";
+
+    fn generate(seed: u64, fuel: usize) -> String {
+        let rng = rand::rngs::SmallRng::seed_from_u64(seed);
         let wat = String::new();
         let mut g = WatGen { rng, wat };
         g.prefix();
@@ -210,7 +256,9 @@ where
         g.suffix();
         g.wat
     }
+}
 
+impl WatGen {
     fn prefix(&mut self) {
         self.wat.push_str(
             "\
@@ -315,13 +363,68 @@ where
     }
 }
 
+/// Use `wasm-opt -ttf` to generate fuzzing test cases.
+pub struct WasmOptTtf;
+
+impl TestCaseGenerator for WasmOptTtf {
+    const NAME: &'static str = "WasmOptTtf";
+
+    fn generate(seed: u64, fuel: usize) -> String {
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+
+        loop {
+            let input: Vec<u8> = (0..fuel).map(|_| rng.gen()).collect();
+
+            let input_tmp = tempfile::NamedTempFile::new().unwrap();
+            fs::write(input_tmp.path(), input).unwrap();
+
+            let wat = walrus_tests_utils::wasm_opt(
+                input_tmp.path(),
+                vec![
+                    "-ttf",
+                    "--emit-text",
+                    // wasm-opt and wat2wasm seem to disagree on some of these.
+                    "--disable-sign-ext",
+                ],
+            )
+            .unwrap();
+            if {
+                // Only generate programs that wat2wasm can handle.
+                let tmp = tempfile::NamedTempFile::new().unwrap();
+                fs::write(tmp.path(), &wat).unwrap();
+                wat2wasm(tmp.path()).is_ok()
+            } {
+                return String::from_utf8(wat).unwrap();
+            }
+        }
+    }
+}
+
+fn print_err(e: &failure::Error) {
+    eprintln!("Error:");
+    for c in e.iter_chain() {
+        eprintln!("  - {}", c);
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
-    fn fuzz() {
-        let mut config = super::Config::new();
-        if let Some(failing_test_case) = config.run() {
-            println!("{}", failing_test_case);
+    fn watgen_fuzz() {
+        let mut config = Config::<WatGen>::new();
+        if let Err(failing_test_case) = config.run() {
+            print_err(&failing_test_case);
+            panic!("Found a failing test case");
+        }
+    }
+
+    #[test]
+    fn wasm_opt_ttf_fuzz() {
+        let mut config = Config::<WasmOptTtf>::new();
+        if let Err(failing_test_case) = config.run() {
+            print_err(&failing_test_case);
             panic!("Found a failing test case");
         }
     }

--- a/crates/fuzz/src/lib.rs
+++ b/crates/fuzz/src/lib.rs
@@ -411,9 +411,19 @@ fn print_err(e: &failure::Error) {
 mod tests {
     use super::*;
 
+    fn get_timeout() -> Option<u64> {
+        use std::str::FromStr;
+        std::env::var("WALRUS_FUZZ_TIMEOUT")
+            .ok()
+            .and_then(|t| u64::from_str(&t).ok())
+    }
+
     #[test]
     fn watgen_fuzz() {
         let mut config = Config::<WatGen>::new();
+        if let Some(t) = get_timeout() {
+            config.timeout = t;
+        }
         if let Err(failing_test_case) = config.run() {
             print_err(&failing_test_case);
             panic!("Found a failing test case");
@@ -423,6 +433,9 @@ mod tests {
     #[test]
     fn wasm_opt_ttf_fuzz() {
         let mut config = Config::<WasmOptTtf>::new();
+        if let Some(t) = get_timeout() {
+            config.timeout = t;
+        }
         if let Err(failing_test_case) = config.run() {
             print_err(&failing_test_case);
             panic!("Found a failing test case");

--- a/crates/tests-utils/Cargo.toml
+++ b/crates/tests-utils/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 tempfile = "3.0"
-failure = "0.1"
+failure = "0.1.5"

--- a/crates/tests-utils/src/lib.rs
+++ b/crates/tests-utils/src/lib.rs
@@ -1,14 +1,22 @@
+use failure::ResultExt;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Once, ONCE_INIT};
 
+pub type Result<T> = std::result::Result<T, failure::Error>;
+
 pub const FEATURES: &[&str] = &[
     "--enable-threads",
     "--enable-bulk-memory",
     "--enable-reference-types",
     "--enable-simd",
+    // TODO
+    // "--enable-saturating-float-to-int",
+    // "--enable-sign-extension",
+    // "--enable-tail-call",
+    // "--enable-annotations",
 ];
 
 fn require_tool(tool: &str, repo: &str) {
@@ -27,11 +35,11 @@ fn require_wat2wasm() {
 }
 
 /// Compile the `.wat` file at the given path into a `.wasm`.
-pub fn wat2wasm(path: &Path) -> Vec<u8> {
+pub fn wat2wasm(path: &Path) -> Result<Vec<u8>> {
     static CHECK: Once = ONCE_INIT;
     CHECK.call_once(require_wat2wasm);
 
-    let file = tempfile::NamedTempFile::new().unwrap();
+    let file = tempfile::NamedTempFile::new().context("could not create named temp file")?;
 
     let mut wasm = PathBuf::from(path);
     wasm.set_extension("wasm");
@@ -43,15 +51,18 @@ pub fn wat2wasm(path: &Path) -> Vec<u8> {
         .arg("-o")
         .arg(file.path());
     println!("running: {:?}", cmd);
-    let output = cmd.output().expect("should spawn wat2wasm OK");
+    let output = cmd.output().context("could not spawn wat2wasm")?;
 
     if !output.status.success() {
-        println!("status: {}", output.status);
-        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
-        panic!("expected ok");
+        failure::bail!(
+            "wat2wasm exited with status {:?}\n\nstderr = '''\n{}\n'''",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
-    fs::read(file.path()).unwrap()
+    let buf = fs::read(file.path())?;
+    Ok(buf)
 }
 
 fn require_wasm2wat() {
@@ -59,7 +70,7 @@ fn require_wasm2wat() {
 }
 
 /// Disassemble the `.wasm` file at the given path into a `.wat`.
-pub fn wasm2wat(path: &Path) -> String {
+pub fn wasm2wat(path: &Path) -> Result<String> {
     static CHECK: Once = ONCE_INIT;
     CHECK.call_once(require_wasm2wat);
 
@@ -67,37 +78,45 @@ pub fn wasm2wat(path: &Path) -> String {
     cmd.arg(path);
     cmd.args(FEATURES);
     println!("running: {:?}", cmd);
-    let output = cmd.output().expect("should spawn wasm2wat OK");
+    let output = cmd.output().context("could not run wasm2wat")?;
     if !output.status.success() {
-        println!("status: {}", output.status);
-        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
-        panic!("expected ok");
+        failure::bail!(
+            "wasm2wat exited with status {:?}\n\nstderr = '''\n{}\n'''",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    String::from_utf8_lossy(&output.stdout).into_owned()
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 fn require_wasm_interp() {
     require_tool("wasm-insterp", "https://github.com/WebAssembly/wabt");
 }
 
-/// Run the wasm-interp on the given wat file.
-pub fn wasm_interp(path: &Path) -> String {
+/// Run `wasm-interp` on the given wat file.
+pub fn wasm_interp(path: &Path) -> Result<String> {
     static CHECK: Once = ONCE_INIT;
     CHECK.call_once(require_wasm_interp);
 
     let mut cmd = Command::new("wasm-interp");
     cmd.arg(path);
     cmd.arg("--run-all-exports");
-    cmd.arg("--host-print");
+    // This requires a build of WABT at least as new as `41adcbfb` to get
+    // `wasm-interp`'s `--dummy-import-func`.
+    cmd.arg("--dummy-import-func");
     cmd.args(FEATURES);
     println!("running: {:?}", cmd);
-    let output = cmd.output().expect("should spawn wasm-interp OK");
+    let output = cmd.output().context("could notrun wasm-interp")?;
     if !output.status.success() {
-        println!("status: {}", output.status);
-        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
-        panic!("expected ok");
+        failure::bail!(
+            "wasm-interp exited with status {:?}\n\nstderr = '''\n{}\n'''",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    String::from_utf8_lossy(&output.stdout).into_owned()
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 fn require_wasm_opt() {
@@ -106,7 +125,7 @@ fn require_wasm_opt() {
 
 /// Run `wasm-opt` on the given input file with optional extra arguments, and
 /// return the resulting wasm binary as an in-memory buffer.
-pub fn wasm_opt<A, S>(input: &Path, args: A) -> Vec<u8>
+pub fn wasm_opt<A, S>(input: &Path, args: A) -> Result<Vec<u8>>
 where
     A: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
@@ -120,15 +139,25 @@ where
     cmd.arg(input);
     cmd.arg("-o");
     cmd.arg(tmp.path());
+    cmd.args(&[
+        "--enable-threads",
+        "--enable-bulk-memory",
+        // "--enable-reference-types",
+        "--enable-simd",
+    ]);
     cmd.args(args);
     println!("running: {:?}", cmd);
-    let output = cmd.output().expect("should spawn wasm-opt OK");
+    let output = cmd.output().context("could not run wasm-opt")?;
     if !output.status.success() {
-        println!("status: {}", output.status);
-        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
-        panic!("expected ok");
+        failure::bail!(
+            "wasm-opt exited with status {:?}\n\nstderr = '''\n{}\n'''",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    fs::read(tmp.path()).unwrap()
+
+    let buf = fs::read(tmp.path())?;
+    Ok(buf)
 }
 
 pub fn handle<T: TestResult>(result: T) {
@@ -143,7 +172,7 @@ impl TestResult for () {
     fn handle(self) {}
 }
 
-impl TestResult for Result<(), failure::Error> {
+impl TestResult for std::result::Result<(), failure::Error> {
     fn handle(self) {
         let err = match self {
             Ok(()) => return,

--- a/crates/tests-utils/src/lib.rs
+++ b/crates/tests-utils/src/lib.rs
@@ -10,19 +10,19 @@ pub const FEATURES: &[&str] = &[
     "--enable-simd",
 ];
 
-fn require_wat2wasm() {
+fn require_tool(tool: &str, repo: &str) {
+    let diagnostic = format!("Could not spawn {}; do you have {} installed?", tool, repo);
     let status = Command::new("wat2wasm")
         .arg("--help")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .expect(
-            "Could not spawn wat2wasm; do you have https://github.com/WebAssembly/wabt installed?",
-        );
-    assert!(
-        status.success(),
-        "wat2wasm did not run OK; do you have https://github.com/WebAssembly/wabt installed?"
-    )
+        .expect(&diagnostic);
+    assert!(status.success(), "{}", diagnostic)
+}
+
+fn require_wat2wasm() {
+    require_tool("wat2wasm", "https://github.com/WebAssembly/wabt");
 }
 
 /// Compile the `.wat` file at the given path into a `.wasm`.
@@ -54,18 +54,7 @@ pub fn wat2wasm(path: &Path) -> Vec<u8> {
 }
 
 fn require_wasm2wat() {
-    let status = Command::new("wasm2wat")
-        .arg("--help")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .expect(
-            "Could not spawn wasm2wat; do you have https://github.com/WebAssembly/wabt installed?",
-        );
-    assert!(
-        status.success(),
-        "wasm2wat did not run OK; do you have https://github.com/WebAssembly/wabt installed?"
-    )
+    require_tool("wasm2wat", "https://github.com/WebAssembly/wabt");
 }
 
 /// Disassemble the `.wasm` file at the given path into a `.wat`.
@@ -87,18 +76,7 @@ pub fn wasm2wat(path: &Path) -> String {
 }
 
 fn require_wasm_interp() {
-    let status = Command::new("wasm-interp")
-        .arg("--help")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .expect(
-            "Could not spawn wasm-interp; do you have https://github.com/WebAssembly/wabt installed?",
-        );
-    assert!(
-        status.success(),
-        "wasm-interp did not run OK; do you have https://github.com/WebAssembly/wabt installed?"
-    )
+    require_tool("wasm-insterp", "https://github.com/WebAssembly/wabt");
 }
 
 /// Run the wasm-interp on the given wat file.

--- a/crates/tests/tests/function_imports.rs
+++ b/crates/tests/tests/function_imports.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use walrus_tests_utils::wat2wasm;
 
 fn run(wat_path: &Path) -> Result<(), failure::Error> {
-    let wasm = wat2wasm(wat_path);
+    let wasm = wat2wasm(wat_path)?;
     let module = walrus::Module::from_buffer(&wasm)?;
 
     assert!(module.imports.find("doggo", "husky").is_some());

--- a/crates/tests/tests/ir.rs
+++ b/crates/tests/tests/ir.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use walrus::dot::Dot;
 
 fn run(wat_path: &Path) -> Result<(), failure::Error> {
-    let wasm = walrus_tests_utils::wat2wasm(wat_path);
+    let wasm = walrus_tests_utils::wat2wasm(wat_path)?;
     let module = walrus::Module::from_buffer(&wasm)?;
 
     let local_funcs: Vec<_> = module

--- a/crates/tests/tests/round_trip.rs
+++ b/crates/tests/tests/round_trip.rs
@@ -5,7 +5,7 @@ use walrus::dot::Dot;
 use walrus_tests_utils::{wasm2wat, wat2wasm};
 
 fn run(wat_path: &Path) -> Result<(), failure::Error> {
-    let wasm = wat2wasm(wat_path);
+    let wasm = wat2wasm(wat_path)?;
     let mut module = walrus::Module::from_buffer(&wasm)?;
 
     if env::var("WALRUS_TESTS_DOT").is_ok() {
@@ -20,7 +20,7 @@ fn run(wat_path: &Path) -> Result<(), failure::Error> {
     walrus::passes::gc::run(&mut module);
     module.emit_wasm_file(&out_wasm_file)?;
 
-    let out_wat = wasm2wat(&out_wasm_file);
+    let out_wat = wasm2wat(&out_wasm_file)?;
     let checker = walrus_tests::FileCheck::from_file(wat_path);
     checker.check(&out_wat);
     Ok(())

--- a/crates/tests/tests/valid.rs
+++ b/crates/tests/tests/valid.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use walrus::dot::Dot;
 
 fn run(wat: &Path) -> Result<(), failure::Error> {
-    let wasm = walrus_tests_utils::wat2wasm(wat);
+    let wasm = walrus_tests_utils::wat2wasm(wat)?;
     let module = walrus::Module::from_buffer(&wasm)?;
 
     let local_funcs: Vec<_> = module

--- a/examples/round-trip.rs
+++ b/examples/round-trip.rs
@@ -1,11 +1,26 @@
-// A small example which is primarily used to help benchmark walrus right now.
+//! A small example which is primarily used to help benchmark walrus right now.
+
+use std::process;
 
 fn main() {
-    env_logger::init();
-    let a = std::env::args().nth(1).unwrap();
-    let m = walrus::Module::from_file(&a).unwrap();
-    let wasm = m.emit_wasm().unwrap();
-    if let Some(destination) = std::env::args().nth(2) {
-        std::fs::write(destination, wasm).unwrap();
+    if let Err(e) = try_main() {
+        eprintln!("Error!");
+        for c in e.iter_chain() {
+            eprintln!("{}", c);
+        }
+        process::exit(1);
     }
+}
+
+fn try_main() -> Result<(), failure::Error> {
+    env_logger::init();
+    let a = std::env::args().nth(1).ok_or_else(|| {
+        failure::format_err!("must provide the input wasm file as the first argument")
+    })?;
+    let m = walrus::Module::from_file(&a)?;
+    let wasm = m.emit_wasm()?;
+    if let Some(destination) = std::env::args().nth(2) {
+        std::fs::write(destination, wasm)?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
The `-ttf` flag stands for "translate to fuzz" and instead of treating the input file as a Wasm binary, it uses it as an stream of "random" values to deterministically generate Wasm test cases. Larger input files lead to larger output Wasm test cases.

This adapts our existing fuzz harness to use either our existing, simple `WatGen` generator or use `wasm-opt -ttf` to generate Wasm files that we will fuzz `walrus` with.

+cc @tlively