### PR TITLE
Update wasmparser to 0.33.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ leb128 = "0.2.3"
 log = "0.4"
 rayon = "1.0.3"
 walrus-macro = { path = './crates/macro', version = '=0.8.0' }
-wasmparser = "0.31"
+wasmparser = "0.33"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/crates/tests/tests/ir/bulk-memory.wat
+++ b/crates/tests/tests/ir/bulk-memory.wat
@@ -1,0 +1,46 @@
+(module
+  (memory 1)
+
+  (func
+    (memory.init 0
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3))
+    (data.drop 2)
+
+    (memory.copy
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3))
+
+    (memory.fill
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3))
+  )
+
+  (data "A")
+  (data (i32.const 0) "b")
+  (data "C")
+)
+
+;; CHECK: (func
+;; NEXT:    (block
+;; NEXT:      (memory.init 0 0
+;; NEXT:        (const 1)
+;; NEXT:        (const 2)
+;; NEXT:        (const 3)
+;; NEXT:      )
+;; NEXT:      (data.drop 2)
+;; NEXT:      (memory.copy 0 0
+;; NEXT:        (const 1)
+;; NEXT:        (const 2)
+;; NEXT:        (const 3)
+;; NEXT:      )
+;; NEXT:      (memory.fill 0
+;; NEXT:        (const 1)
+;; NEXT:        (const 2)
+;; NEXT:        (const 3)
+;; NEXT:      )
+;; NEXT:    )
+;; NEXT:  )

--- a/crates/tests/tests/round_trip/bulk-memory.wat
+++ b/crates/tests/tests/round_trip/bulk-memory.wat
@@ -19,9 +19,9 @@
       (i32.const 3))
   )
 
-  (data passive "A")
+  (data "A")
   (data (i32.const 0) "b")
-  (data passive "C")
+  (data "C")
 )
 
 ;; CHECK: (module
@@ -43,5 +43,5 @@
 ;; NEXT:    (memory (;0;) 1)
 ;; NEXT:    (export "a" (func 0))
 ;; NEXT:    (data (;0;) (i32.const 0) "b")
-;; NEXT:    (data (;1;) passive "A")
-;; NEXT:    (data (;2;) passive "C"))
+;; NEXT:    (data (;1;) "A")
+;; NEXT:    (data (;2;) "C"))

--- a/crates/tests/tests/round_trip/simd.wat
+++ b/crates/tests/tests/round_trip/simd.wat
@@ -16,10 +16,12 @@
     v128.store
   )
 
+(;
   (func $v128.shuffle (export "v128.shuffle") (param v128 v128) (result v128)
     local.get 0
     local.get 1
     v8x16.shuffle 16 1 18 3 20 5 22 7 24 9 26 11 28 13 30 15)
+;)
 
    (func $i8x16.splat (export "i8x16.splat") (param i32) (result v128)
      local.get 0
@@ -526,18 +528,18 @@
     (type (;0;) (func (result v128)))
     (type (;1;) (func (param i32) (result v128)))
     (type (;2;) (func (param i32 v128)))
-    (type (;3;) (func (param v128 v128) (result v128)))
-    (type (;4;) (func (param v128) (result i32)))
-    (type (;5;) (func (param v128 i32) (result v128)))
-    (type (;6;) (func (param i64) (result v128)))
-    (type (;7;) (func (param v128) (result i64)))
-    (type (;8;) (func (param v128 i64) (result v128)))
-    (type (;9;) (func (param f32) (result v128)))
-    (type (;10;) (func (param v128) (result f32)))
-    (type (;11;) (func (param v128 f32) (result v128)))
-    (type (;12;) (func (param f64) (result v128)))
-    (type (;13;) (func (param v128) (result f64)))
-    (type (;14;) (func (param v128 f64) (result v128)))
+    (type (;3;) (func (param v128) (result i32)))
+    (type (;4;) (func (param v128 i32) (result v128)))
+    (type (;5;) (func (param i64) (result v128)))
+    (type (;6;) (func (param v128) (result i64)))
+    (type (;7;) (func (param v128 i64) (result v128)))
+    (type (;8;) (func (param f32) (result v128)))
+    (type (;9;) (func (param v128) (result f32)))
+    (type (;10;) (func (param v128 f32) (result v128)))
+    (type (;11;) (func (param f64) (result v128)))
+    (type (;12;) (func (param v128) (result f64)))
+    (type (;13;) (func (param v128 f64) (result v128)))
+    (type (;14;) (func (param v128 v128) (result v128)))
     (type (;15;) (func (param v128) (result v128)))
     (type (;16;) (func (param v128 v128 v128) (result v128)))
     (func $v128.bitselect (type 16) (param v128 v128 v128) (result v128)
@@ -549,363 +551,359 @@
       local.get 0
       local.get 1
       v128.store)
-    (func $v128.shuffle (type 3) (param v128 v128) (result v128)
-      local.get 0
-      local.get 1
-      v8x16.shuffle  16  1  18  3  20  5  22  7  24  9  26  11  28  13  30  15 )
-    (func $i8x16.replace_lane (type 5) (param v128 i32) (result v128)
+    (func $i8x16.replace_lane (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i8x16.replace_lane 2 )
-    (func $i16x8.replace_lane (type 5) (param v128 i32) (result v128)
+    (func $i16x8.replace_lane (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i16x8.replace_lane 2 )
-    (func $i32x4.replace_lane (type 5) (param v128 i32) (result v128)
+    (func $i32x4.replace_lane (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i32x4.replace_lane 2 )
-    (func $i64x2.replace_lane (type 8) (param v128 i64) (result v128)
+    (func $i64x2.replace_lane (type 7) (param v128 i64) (result v128)
       local.get 0
       local.get 1
       i64x2.replace_lane 0 )
-    (func $f32x4.replace_lane (type 11) (param v128 f32) (result v128)
+    (func $f32x4.replace_lane (type 10) (param v128 f32) (result v128)
       local.get 0
       local.get 1
       f32x4.replace_lane 2 )
-    (func $f64x2.replace_lane (type 14) (param v128 f64) (result v128)
+    (func $f64x2.replace_lane (type 13) (param v128 f64) (result v128)
       local.get 0
       local.get 1
       f64x2.replace_lane 0 )
-    (func $i8x16.eq (type 3) (param v128 v128) (result v128)
+    (func $i8x16.eq (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.eq)
-    (func $i8x16.lt_s (type 3) (param v128 v128) (result v128)
+    (func $i8x16.lt_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.lt_s)
-    (func $i8x16.lt_u (type 3) (param v128 v128) (result v128)
+    (func $i8x16.lt_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.lt_u)
-    (func $i8x16.gt_s (type 3) (param v128 v128) (result v128)
+    (func $i8x16.gt_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.gt_s)
-    (func $i8x16.gt_u (type 3) (param v128 v128) (result v128)
+    (func $i8x16.gt_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.gt_u)
-    (func $i8x16.le_s (type 3) (param v128 v128) (result v128)
+    (func $i8x16.le_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.le_s)
-    (func $i8x16.le_u (type 3) (param v128 v128) (result v128)
+    (func $i8x16.le_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.le_u)
-    (func $i8x16.ge_s (type 3) (param v128 v128) (result v128)
+    (func $i8x16.ge_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.ge_s)
-    (func $i8x16.ge_u (type 3) (param v128 v128) (result v128)
+    (func $i8x16.ge_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.ge_u)
-    (func $i16x8.eq (type 3) (param v128 v128) (result v128)
+    (func $i16x8.eq (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.eq)
-    (func $i16x8.lt_s (type 3) (param v128 v128) (result v128)
+    (func $i16x8.lt_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.lt_s)
-    (func $i16x8.lt_u (type 3) (param v128 v128) (result v128)
+    (func $i16x8.lt_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.lt_u)
-    (func $i16x8.gt_s (type 3) (param v128 v128) (result v128)
+    (func $i16x8.gt_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.gt_s)
-    (func $i16x8.gt_u (type 3) (param v128 v128) (result v128)
+    (func $i16x8.gt_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.gt_u)
-    (func $i16x8.le_s (type 3) (param v128 v128) (result v128)
+    (func $i16x8.le_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.le_s)
-    (func $i16x8.le_u (type 3) (param v128 v128) (result v128)
+    (func $i16x8.le_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.le_u)
-    (func $i16x8.ge_s (type 3) (param v128 v128) (result v128)
+    (func $i16x8.ge_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.ge_s)
-    (func $i16x8.ge_u (type 3) (param v128 v128) (result v128)
+    (func $i16x8.ge_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.ge_u)
-    (func $i32x4.eq (type 3) (param v128 v128) (result v128)
+    (func $i32x4.eq (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.eq)
-    (func $i32x4.lt_s (type 3) (param v128 v128) (result v128)
+    (func $i32x4.lt_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.lt_s)
-    (func $i32x4.lt_u (type 3) (param v128 v128) (result v128)
+    (func $i32x4.lt_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.lt_u)
-    (func $i32x4.gt_s (type 3) (param v128 v128) (result v128)
+    (func $i32x4.gt_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.gt_s)
-    (func $i32x4.gt_u (type 3) (param v128 v128) (result v128)
+    (func $i32x4.gt_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.gt_u)
-    (func $i32x4.le_s (type 3) (param v128 v128) (result v128)
+    (func $i32x4.le_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.le_s)
-    (func $i32x4.le_u (type 3) (param v128 v128) (result v128)
+    (func $i32x4.le_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.le_u)
-    (func $i32x4.ge_s (type 3) (param v128 v128) (result v128)
+    (func $i32x4.ge_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.ge_s)
-    (func $i32x4.ge_u (type 3) (param v128 v128) (result v128)
+    (func $i32x4.ge_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.ge_u)
-    (func $f32x4.eq (type 3) (param v128 v128) (result v128)
+    (func $f32x4.eq (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.eq)
-    (func $f32x4.lt (type 3) (param v128 v128) (result v128)
+    (func $f32x4.lt (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.lt)
-    (func $f32x4.gt (type 3) (param v128 v128) (result v128)
+    (func $f32x4.gt (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.gt)
-    (func $f32x4.le (type 3) (param v128 v128) (result v128)
+    (func $f32x4.le (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.le)
-    (func $f32x4.ge (type 3) (param v128 v128) (result v128)
+    (func $f32x4.ge (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.ge)
-    (func $f64x2.eq (type 3) (param v128 v128) (result v128)
+    (func $f64x2.eq (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.eq)
-    (func $f64x2.lt (type 3) (param v128 v128) (result v128)
+    (func $f64x2.lt (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.lt)
-    (func $f64x2.gt (type 3) (param v128 v128) (result v128)
+    (func $f64x2.gt (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.gt)
-    (func $f64x2.le (type 3) (param v128 v128) (result v128)
+    (func $f64x2.le (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.le)
-    (func $f64x2.ge (type 3) (param v128 v128) (result v128)
+    (func $f64x2.ge (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.ge)
-    (func $v128.and (type 3) (param v128 v128) (result v128)
+    (func $v128.and (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       v128.and)
-    (func $v128.or (type 3) (param v128 v128) (result v128)
+    (func $v128.or (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       v128.or)
-    (func $v128.xor (type 3) (param v128 v128) (result v128)
+    (func $v128.xor (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       v128.xor)
-    (func $i8x16.shl (type 5) (param v128 i32) (result v128)
+    (func $i8x16.shl (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i8x16.shl)
-    (func $i8x16.shr_s (type 5) (param v128 i32) (result v128)
+    (func $i8x16.shr_s (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i8x16.shr_s)
-    (func $i8x16.shr_u (type 5) (param v128 i32) (result v128)
+    (func $i8x16.shr_u (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i8x16.shr_u)
-    (func $i8x16.add (type 3) (param v128 v128) (result v128)
+    (func $i8x16.add (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.add)
-    (func $i8x16.add_saturate_u (type 3) (param v128 v128) (result v128)
+    (func $i8x16.add_saturate_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.add_saturate_u)
-    (func $i8x16.add_saturate_s (type 3) (param v128 v128) (result v128)
+    (func $i8x16.add_saturate_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.add_saturate_s)
-    (func $i8x16.sub (type 3) (param v128 v128) (result v128)
+    (func $i8x16.sub (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.sub)
-    (func $i8x16.sub_saturate_u (type 3) (param v128 v128) (result v128)
+    (func $i8x16.sub_saturate_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.sub_saturate_u)
-    (func $i8x16.sub_saturate_s (type 3) (param v128 v128) (result v128)
+    (func $i8x16.sub_saturate_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.sub_saturate_s)
-    (func $i8x16.mul (type 3) (param v128 v128) (result v128)
+    (func $i8x16.mul (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i8x16.mul)
-    (func $i16x8.shl (type 5) (param v128 i32) (result v128)
+    (func $i16x8.shl (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i16x8.shl)
-    (func $i16x8.shr_s (type 5) (param v128 i32) (result v128)
+    (func $i16x8.shr_s (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i16x8.shr_s)
-    (func $i16x8.shr_u (type 5) (param v128 i32) (result v128)
+    (func $i16x8.shr_u (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i16x8.shr_u)
-    (func $i16x8.add (type 3) (param v128 v128) (result v128)
+    (func $i16x8.add (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.add)
-    (func $i16x8.add_saturate_u (type 3) (param v128 v128) (result v128)
+    (func $i16x8.add_saturate_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.add_saturate_u)
-    (func $i16x8.add_saturate_s (type 3) (param v128 v128) (result v128)
+    (func $i16x8.add_saturate_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.add_saturate_s)
-    (func $i16x8.sub (type 3) (param v128 v128) (result v128)
+    (func $i16x8.sub (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.sub)
-    (func $i16x8.sub_saturate_u (type 3) (param v128 v128) (result v128)
+    (func $i16x8.sub_saturate_u (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.sub_saturate_u)
-    (func $i16x8.sub_saturate_s (type 3) (param v128 v128) (result v128)
+    (func $i16x8.sub_saturate_s (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.sub_saturate_s)
-    (func $i16x8.mul (type 3) (param v128 v128) (result v128)
+    (func $i16x8.mul (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i16x8.mul)
-    (func $i32x4.shl (type 5) (param v128 i32) (result v128)
+    (func $i32x4.shl (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i32x4.shl)
-    (func $i32x4.shr_s (type 5) (param v128 i32) (result v128)
+    (func $i32x4.shr_s (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i32x4.shr_s)
-    (func $i32x4.shr_u (type 5) (param v128 i32) (result v128)
+    (func $i32x4.shr_u (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i32x4.shr_u)
-    (func $i32x4.add (type 3) (param v128 v128) (result v128)
+    (func $i32x4.add (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.add)
-    (func $i32x4.sub (type 3) (param v128 v128) (result v128)
+    (func $i32x4.sub (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.sub)
-    (func $i32x4.mul (type 3) (param v128 v128) (result v128)
+    (func $i32x4.mul (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i32x4.mul)
-    (func $i64x2.shl (type 5) (param v128 i32) (result v128)
+    (func $i64x2.shl (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i64x2.shl)
-    (func $i64x2.shr_s (type 5) (param v128 i32) (result v128)
+    (func $i64x2.shr_s (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i64x2.shr_s)
-    (func $i64x2.shr_u (type 5) (param v128 i32) (result v128)
+    (func $i64x2.shr_u (type 4) (param v128 i32) (result v128)
       local.get 0
       local.get 1
       i64x2.shr_u)
-    (func $i64x2.add (type 3) (param v128 v128) (result v128)
+    (func $i64x2.add (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i64x2.add)
-    (func $i64x2.sub (type 3) (param v128 v128) (result v128)
+    (func $i64x2.sub (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       i64x2.sub)
-    (func $f32x4.add (type 3) (param v128 v128) (result v128)
+    (func $f32x4.add (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.add)
-    (func $f32x4.sub (type 3) (param v128 v128) (result v128)
+    (func $f32x4.sub (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.sub)
-    (func $f32x4.mul (type 3) (param v128 v128) (result v128)
+    (func $f32x4.mul (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.mul)
-    (func $f32x4.div (type 3) (param v128 v128) (result v128)
+    (func $f32x4.div (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.div)
-    (func $f32x4.min (type 3) (param v128 v128) (result v128)
+    (func $f32x4.min (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.min)
-    (func $f32x4.max (type 3) (param v128 v128) (result v128)
+    (func $f32x4.max (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f32x4.max)
-    (func $f64x2.add (type 3) (param v128 v128) (result v128)
+    (func $f64x2.add (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.add)
-    (func $f64x2.sub (type 3) (param v128 v128) (result v128)
+    (func $f64x2.sub (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.sub)
-    (func $f64x2.mul (type 3) (param v128 v128) (result v128)
+    (func $f64x2.mul (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.mul)
-    (func $f64x2.div (type 3) (param v128 v128) (result v128)
+    (func $f64x2.div (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.div)
-    (func $f64x2.min (type 3) (param v128 v128) (result v128)
+    (func $f64x2.min (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.min)
-    (func $f64x2.max (type 3) (param v128 v128) (result v128)
+    (func $f64x2.max (type 14) (param v128 v128) (result v128)
       local.get 0
       local.get 1
       f64x2.max)
@@ -915,43 +913,43 @@
     (func $i8x16.splat (type 1) (param i32) (result v128)
       local.get 0
       i8x16.splat)
-    (func $i8x16.extract_lane_s (type 4) (param v128) (result i32)
+    (func $i8x16.extract_lane_s (type 3) (param v128) (result i32)
       local.get 0
       i8x16.extract_lane_s 1 )
-    (func $i8x16.extract_lane_u (type 4) (param v128) (result i32)
+    (func $i8x16.extract_lane_u (type 3) (param v128) (result i32)
       local.get 0
       i8x16.extract_lane_u 2 )
     (func $i16x8.splat (type 1) (param i32) (result v128)
       local.get 0
       i16x8.splat)
-    (func $i16x8.extract_lane_s (type 4) (param v128) (result i32)
+    (func $i16x8.extract_lane_s (type 3) (param v128) (result i32)
       local.get 0
       i16x8.extract_lane_s 1 )
-    (func $i16x8.extract_lane_u (type 4) (param v128) (result i32)
+    (func $i16x8.extract_lane_u (type 3) (param v128) (result i32)
       local.get 0
       i16x8.extract_lane_u 2 )
     (func $i32x4.splat (type 1) (param i32) (result v128)
       local.get 0
       i32x4.splat)
-    (func $i32x4.extract_lane (type 4) (param v128) (result i32)
+    (func $i32x4.extract_lane (type 3) (param v128) (result i32)
       local.get 0
       i32x4.extract_lane 1 )
-    (func $i64x2.splat (type 6) (param i64) (result v128)
+    (func $i64x2.splat (type 5) (param i64) (result v128)
       local.get 0
       i64x2.splat)
-    (func $i64x2.extract_lane (type 7) (param v128) (result i64)
+    (func $i64x2.extract_lane (type 6) (param v128) (result i64)
       local.get 0
       i64x2.extract_lane 1 )
-    (func $f32x4.splat (type 9) (param f32) (result v128)
+    (func $f32x4.splat (type 8) (param f32) (result v128)
       local.get 0
       f32x4.splat)
-    (func $f32x4.extract_lane (type 10) (param v128) (result f32)
+    (func $f32x4.extract_lane (type 9) (param v128) (result f32)
       local.get 0
       f32x4.extract_lane 1 )
-    (func $f64x2.splat (type 12) (param f64) (result v128)
+    (func $f64x2.splat (type 11) (param f64) (result v128)
       local.get 0
       f64x2.splat)
-    (func $f64x2.extract_lane (type 13) (param v128) (result f64)
+    (func $f64x2.extract_lane (type 12) (param v128) (result f64)
       local.get 0
       f64x2.extract_lane 1 )
     (func $v128.not (type 15) (param v128) (result v128)
@@ -960,37 +958,37 @@
     (func $i8x16.neg (type 15) (param v128) (result v128)
       local.get 0
       i8x16.neg)
-    (func $i8x16.any_true (type 4) (param v128) (result i32)
+    (func $i8x16.any_true (type 3) (param v128) (result i32)
       local.get 0
       i8x16.any_true)
-    (func $i8x16.all_true (type 4) (param v128) (result i32)
+    (func $i8x16.all_true (type 3) (param v128) (result i32)
       local.get 0
       i8x16.all_true)
     (func $i16x8.neg (type 15) (param v128) (result v128)
       local.get 0
       i16x8.neg)
-    (func $i16x8.any_true (type 4) (param v128) (result i32)
+    (func $i16x8.any_true (type 3) (param v128) (result i32)
       local.get 0
       i16x8.any_true)
-    (func $i16x8.all_true (type 4) (param v128) (result i32)
+    (func $i16x8.all_true (type 3) (param v128) (result i32)
       local.get 0
       i16x8.all_true)
     (func $i32x4.neg (type 15) (param v128) (result v128)
       local.get 0
       i32x4.neg)
-    (func $i32x4.any_true (type 4) (param v128) (result i32)
+    (func $i32x4.any_true (type 3) (param v128) (result i32)
       local.get 0
       i32x4.any_true)
-    (func $i32x4.all_true (type 4) (param v128) (result i32)
+    (func $i32x4.all_true (type 3) (param v128) (result i32)
       local.get 0
       i32x4.all_true)
     (func $i64x2.neg (type 15) (param v128) (result v128)
       local.get 0
       i64x2.neg)
-    (func $i64x2.any_true (type 4) (param v128) (result i32)
+    (func $i64x2.any_true (type 3) (param v128) (result i32)
       local.get 0
       i64x2.any_true)
-    (func $i64x2.all_true (type 4) (param v128) (result i32)
+    (func $i64x2.all_true (type 3) (param v128) (result i32)
       local.get 0
       i64x2.all_true)
     (func $f32x4.abs (type 15) (param v128) (result v128)
@@ -1041,7 +1039,6 @@
     (export "v128.const" (func $v128.const))
     (export "v128.load" (func $v128.load))
     (export "v128.store" (func $v128.store))
-    (export "v128.shuffle" (func $v128.shuffle))
     (export "i8x16.splat" (func $i8x16.splat))
     (export "i8x16.extract_lane_s" (func $i8x16.extract_lane_s))
     (export "i8x16.extract_lane_u" (func $i8x16.extract_lane_u))

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -541,6 +541,14 @@ pub enum Expr {
         v2: ExprId,
     },
 
+    /// `v128.swizzle`
+    V128Swizzle {
+        /// The indices we're using to select and generate the final vector
+        indices: ExprId,
+        /// The vector that's being swizzled
+        lanes: ExprId,
+    },
+
     /// `v128.shuffle`
     V128Shuffle {
         /// The indices that are used to create the final vector of this
@@ -548,9 +556,9 @@ pub enum Expr {
         #[walrus(skip_visit)]
         indices: ShuffleIndices,
         /// The first 16 bytes to be indxed (with indices 0..15)
-        lo: ExprId,
+        a: ExprId,
         /// The second 16 bytes to be indxed (with indices 16..31)
-        hi: ExprId,
+        b: ExprId,
     },
 }
 
@@ -1133,6 +1141,7 @@ impl Expr {
             | Expr::RefNull(..)
             | Expr::RefIsNull(..)
             | Expr::V128Bitselect(..)
+            | Expr::V128Swizzle(..)
             | Expr::V128Shuffle(..)
             | Expr::Drop(..) => false,
         }

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -771,10 +771,15 @@ impl Emit<'_, '_> {
                 self.visit(e.mask);
                 self.simd(0x50);
             }
+            V128Swizzle(e) => {
+                self.visit(e.lanes);
+                self.visit(e.indices);
+                self.simd(0xc0);
+            }
             V128Shuffle(e) => {
-                self.visit(e.lo);
-                self.visit(e.hi);
-                self.simd(0x03);
+                self.visit(e.a);
+                self.visit(e.b);
+                self.simd(0xc1);
                 self.encoder.raw(&e.indices);
             }
         }

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -1289,63 +1289,76 @@ fn validate_instruction(ctx: &mut ValidationContext, inst: Operator) -> Result<(
             ctx.push_operand(Some(I32), expr);
         }
 
-        Operator::V8x16Shuffle { lines } => {
-            let (_, hi) = ctx.pop_operand_expected(Some(V128))?;
-            let (_, lo) = ctx.pop_operand_expected(Some(V128))?;
+        // Operator::V8x16Shuffle { .. } => bail!("v8x16.shuffle not supported"),
+
+        Operator::V8x16Swizzle => {
+            let (_, lanes) = ctx.pop_operand_expected(Some(V128))?;
+            let (_, indices) = ctx.pop_operand_expected(Some(V128))?;
+            let expr = ctx.func.alloc(V128Swizzle {
+                lanes,
+                indices,
+            });
+            ctx.push_operand(Some(V128), expr);
+        }
+
+        Operator::V8x16Shuffle { lanes } |
+        Operator::V8x16ShuffleImm { lanes } => {
+            let (_, a) = ctx.pop_operand_expected(Some(V128))?;
+            let (_, b) = ctx.pop_operand_expected(Some(V128))?;
             let expr = ctx.func.alloc(V128Shuffle {
-                indices: lines,
-                lo,
-                hi,
+                indices: lanes,
+                a,
+                b,
             });
             ctx.push_operand(Some(V128), expr);
         }
 
         Operator::I8x16Splat => one_op(ctx, I32, V128, UnaryOp::I8x16Splat)?,
-        Operator::I8x16ExtractLaneS { line: idx } => {
+        Operator::I8x16ExtractLaneS { lane: idx } => {
             one_op(ctx, V128, I32, UnaryOp::I8x16ExtractLaneS { idx })?
         }
-        Operator::I8x16ExtractLaneU { line: idx } => {
+        Operator::I8x16ExtractLaneU { lane: idx } => {
             one_op(ctx, V128, I32, UnaryOp::I8x16ExtractLaneU { idx })?
         }
-        Operator::I8x16ReplaceLane { line: idx } => {
+        Operator::I8x16ReplaceLane { lane: idx } => {
             two_ops(ctx, V128, I32, V128, BinaryOp::I8x16ReplaceLane { idx })?
         }
         Operator::I16x8Splat => one_op(ctx, I32, V128, UnaryOp::I16x8Splat)?,
-        Operator::I16x8ExtractLaneS { line: idx } => {
+        Operator::I16x8ExtractLaneS { lane: idx } => {
             one_op(ctx, V128, I32, UnaryOp::I16x8ExtractLaneS { idx })?
         }
-        Operator::I16x8ExtractLaneU { line: idx } => {
+        Operator::I16x8ExtractLaneU { lane: idx } => {
             one_op(ctx, V128, I32, UnaryOp::I16x8ExtractLaneU { idx })?
         }
-        Operator::I16x8ReplaceLane { line: idx } => {
+        Operator::I16x8ReplaceLane { lane: idx } => {
             two_ops(ctx, V128, I32, V128, BinaryOp::I16x8ReplaceLane { idx })?
         }
         Operator::I32x4Splat => one_op(ctx, I32, V128, UnaryOp::I32x4Splat)?,
-        Operator::I32x4ExtractLane { line: idx } => {
+        Operator::I32x4ExtractLane { lane: idx } => {
             one_op(ctx, V128, I32, UnaryOp::I32x4ExtractLane { idx })?
         }
-        Operator::I32x4ReplaceLane { line: idx } => {
+        Operator::I32x4ReplaceLane { lane: idx } => {
             two_ops(ctx, V128, I32, V128, BinaryOp::I32x4ReplaceLane { idx })?
         }
         Operator::I64x2Splat => one_op(ctx, I64, V128, UnaryOp::I64x2Splat)?,
-        Operator::I64x2ExtractLane { line: idx } => {
+        Operator::I64x2ExtractLane { lane: idx } => {
             one_op(ctx, V128, I64, UnaryOp::I64x2ExtractLane { idx })?
         }
-        Operator::I64x2ReplaceLane { line: idx } => {
+        Operator::I64x2ReplaceLane { lane: idx } => {
             two_ops(ctx, V128, I64, V128, BinaryOp::I64x2ReplaceLane { idx })?
         }
         Operator::F32x4Splat => one_op(ctx, F32, V128, UnaryOp::F32x4Splat)?,
-        Operator::F32x4ExtractLane { line: idx } => {
+        Operator::F32x4ExtractLane { lane: idx } => {
             one_op(ctx, V128, F32, UnaryOp::F32x4ExtractLane { idx })?
         }
-        Operator::F32x4ReplaceLane { line: idx } => {
+        Operator::F32x4ReplaceLane { lane: idx } => {
             two_ops(ctx, V128, F32, V128, BinaryOp::F32x4ReplaceLane { idx })?
         }
         Operator::F64x2Splat => one_op(ctx, F64, V128, UnaryOp::F64x2Splat)?,
-        Operator::F64x2ExtractLane { line: idx } => {
+        Operator::F64x2ExtractLane { lane: idx } => {
             one_op(ctx, V128, F64, UnaryOp::F64x2ExtractLane { idx })?
         }
-        Operator::F64x2ReplaceLane { line: idx } => {
+        Operator::F64x2ReplaceLane { lane: idx } => {
             two_ops(ctx, V128, F64, V128, BinaryOp::F64x2ReplaceLane { idx })?
         }
 


### PR DESCRIPTION
Handle some recent changes in the SIMD spec around shuffles. Also handle
some changes in the bulk memory proposal's text form.