### PR TITLE
Fix `wasm-opt -ttf` fuzzing

### DIFF
--- a/crates/fuzz/src/lib.rs
+++ b/crates/fuzz/src/lib.rs
@@ -89,10 +89,8 @@ impl<G: TestCaseGenerator> Config<G> {
     }
 
     fn round_trip_through_walrus(&self, wasm: &[u8]) -> Result<Vec<u8>> {
-        println!("parsing into walrus::Module");
         let module =
             walrus::Module::from_buffer(&wasm).context("walrus failed to parse the wasm buffer")?;
-        println!("serializing walrus::Module back into wasm");
         let buf = module
             .emit_wasm()
             .context("walrus failed to serialize a module to wasm")?;
@@ -129,8 +127,6 @@ impl<G: TestCaseGenerator> Config<G> {
         let mut seed = rand::thread_rng().gen();
         let mut failing = Ok(());
         loop {
-            println!("-----------------------------------------------------");
-
             let wat = self.gen_wat(seed);
             match self
                 .run_one(&wat)

--- a/crates/fuzz/src/lib.rs
+++ b/crates/fuzz/src/lib.rs
@@ -54,8 +54,9 @@ impl<G: TestCaseGenerator> Config<G> {
             .join("..")
             .join("target")
             .join("walrus-fuzz");
-        fs::create_dir_all(&dir).unwrap();
-        let scratch = tempfile::NamedTempFile::new_in(dir).unwrap();
+        fs::create_dir_all(&dir).expect(&format!("should create directory: {:?}", dir));
+
+        let scratch = tempfile::NamedTempFile::new_in(dir).expect("should create temp file OK");
 
         Config {
             _generator: PhantomData,
@@ -371,8 +372,8 @@ impl TestCaseGenerator for WasmOptTtf {
         loop {
             let input: Vec<u8> = (0..fuel).map(|_| rng.gen()).collect();
 
-            let input_tmp = tempfile::NamedTempFile::new().unwrap();
-            fs::write(input_tmp.path(), input).unwrap();
+            let input_tmp = tempfile::NamedTempFile::new().expect("should create temp file OK");
+            fs::write(input_tmp.path(), input).expect("should write to temp file OK");
 
             let wat =
                 match walrus_tests_utils::wasm_opt(input_tmp.path(), vec!["-ttf", "--emit-text"]) {

--- a/src/passes/validate.rs
+++ b/src/passes/validate.rs
@@ -250,13 +250,4 @@ impl<'a> Visitor<'a> for Validate<'a> {
         self.require_atomic(e.memory, &e.arg, width);
         e.visit(self);
     }
-
-    fn visit_data_id(&mut self, id: &DataId) {
-        // Catch references in `memory.init` and such instructions to active
-        // data segments, which our implementation will generate but in general
-        // shouldn't be allowed.
-        if !self.module.data.get(*id).passive {
-            self.err("referenced data segment is not passive");
-        }
-    }
 }


### PR DESCRIPTION
`wasm-opt -ttf` will assert that it produces valid wasm modules, but it seems that it can still generate sign extension instructions even with `--disable-sign-ext`, which causes validation to fail, and ultimately the process to exit unsuccessfully. Instead, we just skip and try again when `wasm-opt` fails, and do the same for if `wat2wasm` cannot interpret what `wasm-opt` generates (which was why we previously disabled the sign extension instructions).

See also https://github.com/WebAssembly/binaryen/issues/2257