### PR TITLE
Ensure we don't pre-allocate data segments and then not use them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,16 @@ matrix:
     # A job to run our fuzzers a bit longer than the default.
     - name: "fuzz (stable)"
       rust: stable
+      env:
+        # 300 seconds = 5 minutes.
+        - WALRUS_FUZZ_TIMEOUT=300
       script:
-        - WALRUS_FUZZ_TIMEOUT=$((60 * 5)) cargo test -p walrus-fuzz
+        |
+          # When the fuzzing fails, the logs are too big for Travis, so just
+          # show the relevant tail portion of the log.
+          cargo test -p walrus-fuzz > fuzz.log || {
+              tail -n 1000 fuzz.log && exit 1
+          }
 
     - name: "check benches"
       rust: stable

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 rand = { version = "0.7", features = ['small_rng'] }
 tempfile = "3.0.5"
 failure = "0.1.5"
+env_logger = "0.6.2"
 
 [dependencies.walrus]
 path = "../.."

--- a/crates/fuzz/before-after.sh
+++ b/crates/fuzz/before-after.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This script can be used with `creduce` to reduce the size of a WAT test case
+# that has different output before vs after being round tripped through
+# Walrus. I've successfully used it to reduce ~5KiB test cases down to ~100
+# bytes in only a couple minutes!
+#
+# Usage:
+#
+#     creduce walrus/crates/fuzz/before-after.sh path/to/fuzz.wat
+
+set -eux
+
+INPUT="fuzz.wat"
+TEST_FILE="fuzz.wasm"
+OUT_FILE="$TEST_FILE.walrus.wasm"
+ORIG_OUTPUT_FILE="$TEST_FILE.output.txt"
+NEW_OUTPUT_FILE="$OUT_FILE.output.txt"
+
+function interp {
+    wasm-interp \
+        --run-all-exports \
+        --dummy-import-func \
+        --enable-threads \
+        --enable-bulk-memory \
+        --enable-reference-types \
+        --enable-simd \
+        "$1"
+}
+
+wat2wasm "$INPUT" -o "$TEST_FILE" --enable-simd --enable-bulk-memory
+interp "$TEST_FILE" > "$ORIG_OUTPUT_FILE"
+
+cargo run \
+      --manifest-path "$(dirname "$0")/../../Cargo.toml" \
+      --example round-trip \
+      "$TEST_FILE" \
+      "$OUT_FILE"
+
+interp "$OUT_FILE" > "$NEW_OUTPUT_FILE"
+
+! diff -U3 "$ORIG_OUTPUT_FILE" "$NEW_OUTPUT_FILE"

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -15,6 +15,7 @@ walrus-tests-utils = { path = "../tests-utils" }
 tempfile = "3"
 serde_json = { version = "1", features = ['preserve_order'] }
 serde = { version = "1", features = ['derive'] }
+env_logger = "0.6.2"
 
 [lib]
 doctest = false

--- a/crates/tests/tests/function_imports.rs
+++ b/crates/tests/tests/function_imports.rs
@@ -2,6 +2,11 @@ use std::path::Path;
 use walrus_tests_utils::wat2wasm;
 
 fn run(wat_path: &Path) -> Result<(), failure::Error> {
+    static INIT_LOGS: std::sync::Once = std::sync::Once::new();
+    INIT_LOGS.call_once(|| {
+        env_logger::init();
+    });
+
     let wasm = wat2wasm(wat_path)?;
     let module = walrus::Module::from_buffer(&wasm)?;
 

--- a/crates/tests/tests/round_trip.rs
+++ b/crates/tests/tests/round_trip.rs
@@ -5,6 +5,11 @@ use walrus::dot::Dot;
 use walrus_tests_utils::{wasm2wat, wat2wasm};
 
 fn run(wat_path: &Path) -> Result<(), failure::Error> {
+    static INIT_LOGS: std::sync::Once = std::sync::Once::new();
+    INIT_LOGS.call_once(|| {
+        env_logger::init();
+    });
+
     let wasm = wat2wasm(wat_path)?;
     let mut module = walrus::Module::from_buffer(&wasm)?;
 

--- a/crates/tests/tests/round_trip/bulk-memory.wat
+++ b/crates/tests/tests/round_trip/bulk-memory.wat
@@ -24,24 +24,26 @@
   (data "C")
 )
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func))
-;; NEXT:    (func (;0;) (type 0)
-;; NEXT:      i32.const 1
-;; NEXT:      i32.const 2
-;; NEXT:      i32.const 3
-;; NEXT:      memory.init 1
-;; NEXT:      data.drop 2
-;; NEXT:      i32.const 1
-;; NEXT:      i32.const 2
-;; NEXT:      i32.const 3
-;; NEXT:      memory.copy
-;; NEXT:      i32.const 1
-;; NEXT:      i32.const 2
-;; NEXT:      i32.const 3
-;; NEXT:      memory.fill)
-;; NEXT:    (memory (;0;) 1)
-;; NEXT:    (export "a" (func 0))
-;; NEXT:    (data (;0;) (i32.const 0) "b")
-;; NEXT:    (data (;1;) "A")
-;; NEXT:    (data (;2;) "C"))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func (;0;) (type 0)
+      i32.const 1
+      i32.const 2
+      i32.const 3
+      memory.init 0
+      data.drop 2
+      i32.const 1
+      i32.const 2
+      i32.const 3
+      memory.copy
+      i32.const 1
+      i32.const 2
+      i32.const 3
+      memory.fill)
+    (memory (;0;) 1)
+    (export "a" (func 0))
+    (data (;0;) "A")
+    (data (;1;) (i32.const 0) "b")
+    (data (;2;) "C"))
+;)

--- a/crates/tests/tests/round_trip/fuzz-0.wat
+++ b/crates/tests/tests/round_trip/fuzz-0.wat
@@ -1,0 +1,16 @@
+(module
+ (memory 1)
+ (data (i32.const 0))
+ (export "" (func $b))
+ (func $b
+   data.drop 0))
+
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func $b (type 0)
+      data.drop 0)
+    (memory (;0;) 1)
+    (export "" (func $b))
+    (data (;0;) (i32.const 0) ""))
+;)

--- a/crates/tests/tests/spec-tests.rs
+++ b/crates/tests/tests/spec-tests.rs
@@ -11,6 +11,11 @@ struct Test {
 }
 
 fn run(wast: &Path) -> Result<(), failure::Error> {
+    static INIT_LOGS: std::sync::Once = std::sync::Once::new();
+    INIT_LOGS.call_once(|| {
+        env_logger::init();
+    });
+
     let proposal = wast
         .iter()
         .skip_while(|part| *part != "proposals")

--- a/crates/tests/tests/valid.rs
+++ b/crates/tests/tests/valid.rs
@@ -4,6 +4,11 @@ use std::path::Path;
 use walrus::dot::Dot;
 
 fn run(wat: &Path) -> Result<(), failure::Error> {
+    static INIT_LOGS: std::sync::Once = std::sync::Once::new();
+    INIT_LOGS.call_once(|| {
+        env_logger::init();
+    });
+
     let wasm = walrus_tests_utils::wat2wasm(wat)?;
     let module = walrus::Module::from_buffer(&wasm)?;
 

--- a/src/module/data.rs
+++ b/src/module/data.rs
@@ -4,28 +4,61 @@ use crate::emit::{Emit, EmitContext, Section};
 use crate::ir::Value;
 use crate::parse::IndicesToIds;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
-use crate::{InitExpr, Module, Result, ValType};
+use crate::{GlobalId, InitExpr, MemoryId, Module, Result, ValType};
 use failure::{bail, ResultExt};
 
 /// A passive element segment identifier
 pub type DataId = Id<Data>;
 
-/// A passive data segment
+/// A data segment.
+///
+/// Every data segment has an associated value. This value gets copied into a
+/// memory. It is either automatically copied into a specific memory at Wasm
+/// instantiation time (active data segments) or dynamically copied into a
+/// memory (or memories) via the `memory.init` instruction (passive data
+/// segments). See the `kind` member and `DataKind` type for more details on the
+/// active/passive distinction.
 #[derive(Debug)]
 pub struct Data {
     id: DataId,
-
-    /// Initially set to `false` when reserving `Data` entries while parsing,
-    /// and then read during validation to ensure that `memory.init`
-    /// instructions only reference valid `Data` entries (ones that are actually
-    /// passive).
-    ///
-    /// From a user-facing perspective, though, this is always `true` for all
-    /// instances of `Data` as `Data` only makes sense as a passive segment.
-    pub(crate) passive: bool,
-
-    /// The payload of this passive data segment
+    /// What kind of data segment is this? Passive or active?
+    pub kind: DataKind,
+    /// The data payload of this data segment.
     pub value: Vec<u8>,
+}
+
+/// The kind of data segment: passive or active.
+#[derive(Debug)]
+pub enum DataKind {
+    /// An active data segment that is automatically initialized at some address
+    /// in a static memory.
+    Active(ActiveData),
+    /// A passive data segment that must be manually initialized at a dynamic
+    /// address via the `memory.init` instruction (perhaps multiple times in
+    /// multiple different memories) and then manually freed when it's no longer
+    /// needed via the `data.drop` instruction.
+    Passive,
+}
+
+/// The parts of a data segment that are only present in active data segments.
+#[derive(Clone, Debug)]
+pub struct ActiveData {
+    /// The memory that this active data segment will be automatically
+    /// initialized in.
+    pub memory: MemoryId,
+    /// The memory location where this active data segment will be automatically
+    /// initialized.
+    pub location: ActiveDataLocation,
+}
+
+/// The memory location where an active data segment will be automatically
+/// initialized.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActiveDataLocation {
+    /// A static, absolute address within the memory.
+    Absolute(u32),
+    /// A relative address (expressed as a global's value) within the memory.
+    Relative(GlobalId),
 }
 
 impl Tombstone for Data {
@@ -38,6 +71,14 @@ impl Data {
     /// Returns the id of this passive data segment
     pub fn id(&self) -> DataId {
         self.id
+    }
+
+    /// Is this a passive data segment?
+    pub fn is_passive(&self) -> bool {
+        match self.kind {
+            DataKind::Passive => true,
+            _ => false,
+        }
     }
 }
 
@@ -72,39 +113,30 @@ impl ModuleData {
         self.arena.iter().map(|(_, f)| f)
     }
 
-    /// Adds a new passive data segment with the specified contents
-    pub fn add(&mut self, value: Vec<u8>) -> DataId {
-        self.arena.alloc_with_id(|id| Data {
-            id,
-            value,
-            passive: true,
-        })
-    }
-
     // Note that this is inaccordance with the upstream bulk memory proposal to
     // WebAssembly and isn't currently part of the WebAssembly standard.
     pub(crate) fn emit_data_count(&self, cx: &mut EmitContext) {
         let mut count = 0;
 
-        // The first elements in the index space will be active segments, so
-        // count all those first. Here we push an "invalid id", or one we know
-        // isn't ever used, as the low data segments.
-        for mem in cx.module.memories.iter() {
-            count += mem.emit_data().count();
-        }
-
-        // After the active data segments, assign indices to the passive data
-        // segments.
-        let mut any_passive = false;
         for data in self.iter() {
             cx.indices.set_data_index(data.id(), count as u32);
             count += 1;
-            any_passive = true;
         }
 
-        if any_passive {
-            cx.start_section(Section::DataCount).encoder.usize(count);
-        }
+        // Technically, we /could/ emit slightly smaller binaries by only adding
+        // this section when either:
+        //
+        // * there are passive data segments, or
+        //
+        // * there are `memory.init` or `data.drop` instructions (99.99% overlap
+        //   with the previous case, but you technically can try and drop active
+        //   data segments and get a runtime error!)
+        //
+        // However, checking that second case can be somewhat expensive (iterate
+        // over every instruction in every function), so we just always emit the
+        // `DataCount` section when we have data segments. At most this is five
+        // unnecessary bytes, so not a big deal in the grand scheme of things.
+        cx.start_section(Section::DataCount).encoder.usize(count);
     }
 }
 
@@ -117,11 +149,14 @@ impl Module {
     /// they're actually passive or not, and that property is checked during
     /// validation.
     pub(crate) fn reserve_data(&mut self, count: u32, ids: &mut IndicesToIds) {
+        log::debug!("reserving space for {} data segments", count);
         for _ in 0..count {
             ids.push_data(self.data.arena.alloc_with_id(|id| Data {
                 id,
-                passive: false, // this'll get set to `true` when parsing data
+                // NB: We'll update the `value` and `kind` once we actually
+                // parse the data segments.
                 value: Vec::new(),
+                kind: DataKind::Passive,
             }));
         }
     }
@@ -142,32 +177,50 @@ impl Module {
         for (i, segment) in section.into_iter().enumerate() {
             let segment = segment?;
 
+            // If we had the `DataCount` section, then we already pre-allocated
+            // a data segment. Otherwise, allocate one now.
+            let id = if data_count.is_some() {
+                ids.get_data(i as u32)?
+            } else {
+                self.data.arena.alloc_with_id(|id| Data {
+                    id,
+                    value: Vec::new(),
+                    kind: DataKind::Passive,
+                })
+            };
+            let data = self.data.get_mut(id);
+
             match segment.kind {
                 wasmparser::DataKind::Passive => {
-                    let id = ids.get_data(i as u32)?;
-                    let data = self.data.get_mut(id);
                     data.value = segment.data.to_vec();
-                    data.passive = true;
+                    data.kind = DataKind::Passive;
                 }
                 wasmparser::DataKind::Active {
                     memory_index,
                     init_expr,
                 } => {
-                    let memory = ids.get_memory(memory_index)?;
-                    let value = segment.data.to_vec();
-                    let memory = self.memories.get_mut(memory);
+                    data.value = segment.data.to_vec();
+
+                    let memory_id = ids.get_memory(memory_index)?;
+                    let memory = self.memories.get_mut(memory_id);
+                    memory.data_segments.insert(data.id);
 
                     let offset = InitExpr::eval(&init_expr, ids)
                         .with_context(|_e| format!("in segment {}", i))?;
-                    match offset {
-                        InitExpr::Value(Value::I32(n)) => {
-                            memory.data.add_absolute(n as u32, value);
-                        }
-                        InitExpr::Global(global) if self.globals.get(global).ty == ValType::I32 => {
-                            memory.data.add_relative(global, value);
-                        }
-                        _ => bail!("non-i32 constant in segment {}", i),
-                    }
+                    data.kind = DataKind::Active(ActiveData {
+                        memory: memory_id,
+                        location: match offset {
+                            InitExpr::Value(Value::I32(n)) => {
+                                ActiveDataLocation::Absolute(n as u32)
+                            }
+                            InitExpr::Global(global)
+                                if self.globals.get(global).ty == ValType::I32 =>
+                            {
+                                ActiveDataLocation::Relative(global)
+                            }
+                            _ => bail!("non-i32 constant in segment {}", i),
+                        },
+                    });
                 }
             }
         }
@@ -178,46 +231,38 @@ impl Module {
 impl Emit for ModuleData {
     fn emit(&self, cx: &mut EmitContext) {
         log::debug!("emit data section");
-        // Sort table ids for a deterministic emission for now, eventually we
-        // may want some sort of sorting heuristic here.
-        let mut active = cx
-            .module
-            .memories
-            .iter()
-            .flat_map(|memory| memory.emit_data().map(move |data| (memory.id(), data)))
-            .collect::<Vec<_>>();
-        active.sort_by_key(|pair| pair.0);
-        let passive = self.iter().count();
-
-        if active.len() == 0 && passive == 0 {
+        if self.arena.len() == 0 {
             return;
         }
 
         let mut cx = cx.start_section(Section::Data);
-        cx.encoder.usize(active.len() + passive);
+        cx.encoder.usize(self.arena.len());
 
         // The encodings here are with respect to the bulk memory proposal, but
-        // should be backwards compatible with the current stable WebAssembly
-        // spec so long as only memory 0 is used.
-        for (id, (offset, data)) in active {
-            let index = cx.indices.get_memory_index(id);
-            if index == 0 {
-                cx.encoder.byte(0x00);
-            } else {
-                cx.encoder.byte(0x02);
-                cx.encoder.u32(index);
-            }
-            offset.emit(&mut cx);
-            cx.encoder.bytes(data);
-        }
-
-        // After all the active segments are added add passive segments next. We
-        // may want to sort this more intelligently in the future. Otherwise
-        // emitting a segment here is in general much simpler than above as we
-        // know there are no holes.
+        // should be backwards compatible with the current MVP WebAssembly spec
+        // so long as the only memory 0 is used.
         for data in self.iter() {
-            cx.encoder.byte(0x01);
-            cx.encoder.bytes(&data.value);
+            match data.kind {
+                DataKind::Passive => {
+                    cx.encoder.byte(0x01);
+                    cx.encoder.bytes(&data.value);
+                }
+                DataKind::Active(ref a) => {
+                    let index = cx.indices.get_memory_index(a.memory);
+                    if index == 0 {
+                        cx.encoder.byte(0x00);
+                    } else {
+                        cx.encoder.byte(0x02);
+                        cx.encoder.u32(index);
+                    }
+                    let init_expr = match a.location {
+                        ActiveDataLocation::Absolute(a) => InitExpr::Value(Value::I32(a as i32)),
+                        ActiveDataLocation::Relative(g) => InitExpr::Global(g),
+                    };
+                    init_expr.emit(&mut cx);
+                    cx.encoder.bytes(&data.value);
+                }
+            }
         }
     }
 }

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -1304,14 +1304,10 @@ fn validate_instruction(ctx: &mut ValidationContext, inst: Operator) -> Result<(
         }
 
         // Operator::V8x16Shuffle { .. } => bail!("v8x16.shuffle not supported"),
-
         Operator::V8x16Swizzle => {
             let (_, lanes) = ctx.pop_operand_expected(Some(V128))?;
             let (_, indices) = ctx.pop_operand_expected(Some(V128))?;
-            let expr = ctx.func.alloc(V128Swizzle {
-                lanes,
-                indices,
-            });
+            let expr = ctx.func.alloc(V128Swizzle { lanes, indices });
             ctx.push_operand(Some(V128), expr);
         }
 
@@ -1516,18 +1512,10 @@ fn validate_instruction(ctx: &mut ValidationContext, inst: Operator) -> Result<(
         Operator::I64TruncSSatF64 => one_op(ctx, F64, I64, UnaryOp::I64TruncSSatF64)?,
         Operator::I64TruncUSatF64 => one_op(ctx, F64, I64, UnaryOp::I64TruncUSatF64)?,
 
-        Operator::I8x16LoadSplat { memarg } => {
-            load_splat(ctx, memarg, LoadSplatKind::I8)?
-        }
-        Operator::I16x8LoadSplat { memarg } => {
-            load_splat(ctx, memarg, LoadSplatKind::I16)?
-        }
-        Operator::I32x4LoadSplat { memarg } => {
-            load_splat(ctx, memarg, LoadSplatKind::I32)?
-        }
-        Operator::I64x2LoadSplat { memarg } => {
-            load_splat(ctx, memarg, LoadSplatKind::I64)?
-        }
+        Operator::I8x16LoadSplat { memarg } => load_splat(ctx, memarg, LoadSplatKind::I8)?,
+        Operator::I16x8LoadSplat { memarg } => load_splat(ctx, memarg, LoadSplatKind::I16)?,
+        Operator::I32x4LoadSplat { memarg } => load_splat(ctx, memarg, LoadSplatKind::I32)?,
+        Operator::I64x2LoadSplat { memarg } => load_splat(ctx, memarg, LoadSplatKind::I64)?,
 
         op @ Operator::TableInit { .. }
         | op @ Operator::ElemDrop { .. }

--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -160,7 +160,12 @@ impl Module {
     }
 
     /// Add an imported function to this module
-    pub fn add_import_func(&mut self, module: &str, name: &str, ty: TypeId) -> (FunctionId, ImportId) {
+    pub fn add_import_func(
+        &mut self,
+        module: &str,
+        name: &str,
+        ty: TypeId,
+    ) -> (FunctionId, ImportId) {
         let import = self.imports.arena.next_id();
         let func = self.funcs.add_import(ty, import);
         self.imports.add(module, name, func);

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -21,7 +21,7 @@ pub use crate::module::custom::{
     CustomSection, CustomSectionId, ModuleCustomSections, RawCustomSection, TypedCustomSectionId,
     UntypedCustomSectionId,
 };
-pub use crate::module::data::{Data, DataId, ModuleData};
+pub use crate::module::data::{ActiveData, ActiveDataLocation, Data, DataId, DataKind, ModuleData};
 pub use crate::module::elements::{Element, ElementId, ModuleElements};
 pub use crate::module::exports::{Export, ExportId, ExportItem, ModuleExports};
 pub use crate::module::functions::{Function, FunctionId, ModuleFunctions};
@@ -29,7 +29,7 @@ pub use crate::module::functions::{FunctionKind, LocalFunction};
 pub use crate::module::globals::{Global, GlobalId, GlobalKind, ModuleGlobals};
 pub use crate::module::imports::{Import, ImportId, ImportKind, ModuleImports};
 pub use crate::module::locals::ModuleLocals;
-pub use crate::module::memories::{Memory, MemoryData, MemoryId, ModuleMemories};
+pub use crate::module::memories::{Memory, MemoryId, ModuleMemories};
 pub use crate::module::producers::ModuleProducers;
 pub use crate::module::tables::FunctionTable;
 pub use crate::module::tables::{ModuleTables, Table, TableId, TableKind};

--- a/src/passes/validate.rs
+++ b/src/passes/validate.rs
@@ -5,7 +5,7 @@
 
 use crate::ir::*;
 use crate::ValType;
-use crate::{DataId, Function, FunctionKind, InitExpr, LocalFunction, Result};
+use crate::{Function, FunctionKind, InitExpr, LocalFunction, Result};
 use crate::{Global, GlobalKind, Memory, MemoryId, Module, Table, TableKind};
 use failure::{bail, ResultExt};
 use rayon::prelude::*;


### PR DESCRIPTION
We were pre-allocating data segments based on the `DataCount` section that we
parsed, but then only re-using those pre-allocated data segments for passive
data segments. For active segments, we created a different structure inside the
module's `Memory`. Then, when we emitted the module again, we would emit
duplicate data segments: both the unused pre-allocated segment and the segment
in the module's `Memory`. Add in the interaction with `data.drop` and which of
the duplicate data segments does it reference, and you get bugs!

Thanks `wasm-opt -ttf` for finding this bug for us :)

Anyways, this commit refactors the way we do data segments (in a breaking way!
we'll need to bump the major version on the next release) so that `ModuleData`
contains all of the data segments, not just the passive segments. And memories
just reference the active data segments that affect them, rather than owning
them. No more duplication and splitting where data segments live depending on
what kind of data segment they are!

Fixes #109
