### PR TITLE
Make `rayon` an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ matrix:
 script:
   - cargo build --all
   - cargo test --all
+  - cargo test --features parallel
+  - cargo test --features parallel --manifest-path crates/tests/Cargo.toml
 
 notifications:
   email:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,15 @@ harness = false
 
 [dependencies]
 failure = "0.1.2"
-id-arena = { version = "2.2.1", features = ['rayon'] }
+id-arena = "2.2.1"
 leb128 = "0.2.3"
 log = "0.4"
-rayon = "1.0.3"
+rayon = { version = "1.0.3", optional = true }
 walrus-macro = { path = './crates/macro', version = '=0.9.0' }
 wasmparser = "0.34"
+
+[features]
+parallel = ['rayon', 'id-arena/rayon']
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -17,6 +17,9 @@ serde_json = { version = "1", features = ['preserve_order'] }
 serde = { version = "1", features = ['derive'] }
 env_logger = "0.6.2"
 
+[features]
+parallel = ['walrus/parallel']
+
 [lib]
 doctest = false
 test = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,20 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 
+#[cfg(feature = "parallel")]
+macro_rules! maybe_parallel {
+    ($e:ident.($serial:ident | $parallel:ident)) => {
+        $e.$parallel()
+    };
+}
+
+#[cfg(not(feature = "parallel"))]
+macro_rules! maybe_parallel {
+    ($e:ident.($serial:ident | $parallel:ident)) => {
+        $e.$serial()
+    };
+}
+
 mod arena_set;
 pub mod dot;
 mod emit;

--- a/src/tombstone_arena.rs
+++ b/src/tombstone_arena.rs
@@ -1,8 +1,11 @@
 use crate::map::IdHashSet;
 use id_arena::Arena as InnerArena;
-use rayon::iter::plumbing::UnindexedConsumer;
-use rayon::prelude::*;
 use std::ops::{Index, IndexMut};
+
+#[cfg(feature = "parallel")]
+use rayon::iter::plumbing::UnindexedConsumer;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 pub use id_arena::Id;
 
@@ -105,6 +108,7 @@ impl<T> TombstoneArena<T> {
         }
     }
 
+    #[cfg(feature = "parallel")]
     pub fn par_iter(&self) -> impl ParallelIterator<Item = (Id<T>, &T)>
     where
         T: Sync,
@@ -114,6 +118,7 @@ impl<T> TombstoneArena<T> {
             .filter(move |&(id, _)| !self.dead.contains(&id))
     }
 
+    #[cfg(feature = "parallel")]
     pub fn par_iter_mut(&mut self) -> ParIterMut<T>
     where
         T: Send + Sync,
@@ -161,11 +166,13 @@ impl<'a, T: 'a> Iterator for IterMut<'a, T> {
 }
 
 #[derive(Debug)]
+#[cfg(feature = "parallel")]
 pub struct ParIterMut<'a, T: 'a + Send + Sync> {
     dead: &'a IdHashSet<T>,
     inner: id_arena::ParIterMut<'a, T, id_arena::DefaultArenaBehavior<T>>,
 }
 
+#[cfg(feature = "parallel")]
 impl<'a, T> ParallelIterator for ParIterMut<'a, T>
 where
     T: Send + Sync,


### PR DESCRIPTION
This commit makes `rayon` an optional dependency because it is known to
not work on targets such as WebAssembly by default. Additionally it's
not necessarily guaranteed that all users of `walrus` want its parallel
processing capabilties, so this may help it make a lighter dependency in
those situations!

The main use case for me though was I was playing around with some wasm
tooling in Rust compiled to wasm but `walrus` didn't work out-of-the-box
in that context due to its usage of parallel iterators.