### PR TITLE
Adding ModuleExports getters for FunctionId, TableId, MemoryId and GlobalId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ crates/tests/tests/**/*.dot
 crates/tests/tests/**/*.out
 crates/tests/tests/**/*.out.wasm
 crates/tests/tests/**/*.out.wat
+
+.vscode

--- a/src/module/exports.rs
+++ b/src/module/exports.rs
@@ -240,34 +240,113 @@ impl From<TableId> for ExportItem {
 mod tests {
     use super::*;
     use crate::{FunctionBuilder, Module};
+    use id_arena::Arena;
 
     #[test]
     fn get_exported_func() {
         let mut module = Module::default();
         let mut builder = FunctionBuilder::new(&mut module.types, &[], &[]);
         builder.func_body().i32_const(1234).drop();
-        let function_id = builder.finish(vec![], &mut module.funcs);
-        module.exports.add("dummy", function_id);
+        let id: FunctionId = builder.finish(vec![], &mut module.funcs);
+        module.exports.add("dummy", id);
 
-        let actual: Option<&Export> = module.exports.get_exported_func(function_id);
+        let actual: Option<&Export> = module.exports.get_exported_func(id);
 
         let export: &Export = actual.expect("Expected Some(Export) got None");
         assert_eq!(export.name, "dummy");
         match export.item {
-            ExportItem::Function(f) => assert_eq!(f, function_id),
-            _ => panic!("Expected a Function"),
+            ExportItem::Function(f) => assert_eq!(f, id),
+            _ => panic!("Expected a Function variant"),
         }
     }
 
     #[test]
     fn get_exported_func_should_return_none_for_unknown_function_id() {
-        let mut module = Module::default();
-        let mut builder = FunctionBuilder::new(&mut module.types, &[], &[]);
-        builder.func_body().i32_const(1234).drop();
-        let function_id = builder.finish(vec![], &mut module.funcs);
+        let module = Module::default();
+        let arena: Arena<Function> = Arena::new();
+        let id: FunctionId = arena.next_id();
 
-        let actual: Option<&Export> = module.exports.get_exported_func(function_id);
+        let actual: Option<&Export> = module.exports.get_exported_func(id);
 
         assert!(actual.is_none());
     }
+
+    #[test]
+    fn get_exported_table() {
+        let mut module = Module::default();
+        let arena: Arena<Table> = Arena::new();
+        let id: TableId = arena.next_id();
+        module.exports.add("dummy", id);
+
+        let actual: Option<&Export> = module.exports.get_exported_table(id);
+
+        let export: &Export = actual.expect("Expected Some(Export) got None");
+        assert_eq!(export.name, "dummy");
+        match export.item {
+            ExportItem::Table(f) => assert_eq!(f, id),
+            _ => panic!("Expected a Table variant"),
+        }
+    }
+
+    #[test]
+    fn get_exported_table_should_return_non_for_unknown_table_id() {
+        let module = Module::default();
+        let arena: Arena<Table> = Arena::new();
+        let id: TableId = arena.next_id();
+        let actual: Option<&Export> = module.exports.get_exported_table(id);
+        assert!(actual.is_none());
+    }
+
+    #[test]
+    fn get_exported_memory() {
+        let mut module = Module::default();
+        let arena: Arena<Memory> = Arena::new();
+        let id: MemoryId = arena.next_id();
+        module.exports.add("dummy", id);
+
+        let actual: Option<&Export> = module.exports.get_exported_memory(id);
+
+        let export: &Export = actual.expect("Expected Some(Export) got None");
+        assert_eq!(export.name, "dummy");
+        match export.item {
+            ExportItem::Memory(f) => assert_eq!(f, id),
+            _ => panic!("Expected a Memory variant"),
+        }
+    }
+
+    #[test]
+    fn get_exported_memory_should_return_none_for_unknown_memory_id() {
+        let module = Module::default();
+        let arena: Arena<Memory> = Arena::new();
+        let id: MemoryId = arena.next_id();
+        let actual: Option<&Export> = module.exports.get_exported_memory(id);
+        assert!(actual.is_none());
+    }
+
+    #[test]
+    fn get_exported_global() {
+        let mut module = Module::default();
+        let arena: Arena<Global> = Arena::new();
+        let id: GlobalId = arena.next_id();
+        module.exports.add("dummy", id);
+
+        let actual: Option<&Export> = module.exports.get_exported_global(id);
+
+        let export: &Export = actual.expect("Expected Some(Export) got None");
+        assert_eq!(export.name, "dummy");
+        match export.item {
+            ExportItem::Global(f) => assert_eq!(f, id),
+            _ => panic!("Expected a Global variant"),
+        }
+    }
+
+    #[test]
+    fn get_exported_global_should_return_none_for_unknown_global_id() {
+        let module = Module::default();
+        let arena: Arena<Global> = Arena::new();
+        let id: GlobalId = arena.next_id();
+        let actual: Option<&Export> = module.exports.get_exported_global(id);
+        assert!(actual.is_none());
+    }
+
 }

--- a/src/module/exports.rs
+++ b/src/module/exports.rs
@@ -242,6 +242,11 @@ mod tests {
     use crate::{FunctionBuilder, Module};
     use id_arena::Arena;
 
+    fn generate_id<T>() -> Id<T> {
+        let arena: Arena<T> = Arena::new();
+        arena.next_id()
+    }
+
     #[test]
     fn get_exported_func() {
         let mut module = Module::default();
@@ -263,19 +268,15 @@ mod tests {
     #[test]
     fn get_exported_func_should_return_none_for_unknown_function_id() {
         let module = Module::default();
-        let arena: Arena<Function> = Arena::new();
-        let id: FunctionId = arena.next_id();
-
+        let id: FunctionId = generate_id();
         let actual: Option<&Export> = module.exports.get_exported_func(id);
-
         assert!(actual.is_none());
     }
 
     #[test]
     fn get_exported_table() {
         let mut module = Module::default();
-        let arena: Arena<Table> = Arena::new();
-        let id: TableId = arena.next_id();
+        let id: TableId = generate_id();
         module.exports.add("dummy", id);
 
         let actual: Option<&Export> = module.exports.get_exported_table(id);
@@ -291,8 +292,7 @@ mod tests {
     #[test]
     fn get_exported_table_should_return_non_for_unknown_table_id() {
         let module = Module::default();
-        let arena: Arena<Table> = Arena::new();
-        let id: TableId = arena.next_id();
+        let id: TableId = generate_id();
         let actual: Option<&Export> = module.exports.get_exported_table(id);
         assert!(actual.is_none());
     }
@@ -300,8 +300,7 @@ mod tests {
     #[test]
     fn get_exported_memory() {
         let mut module = Module::default();
-        let arena: Arena<Memory> = Arena::new();
-        let id: MemoryId = arena.next_id();
+        let id: MemoryId = generate_id();
         module.exports.add("dummy", id);
 
         let actual: Option<&Export> = module.exports.get_exported_memory(id);
@@ -317,8 +316,7 @@ mod tests {
     #[test]
     fn get_exported_memory_should_return_none_for_unknown_memory_id() {
         let module = Module::default();
-        let arena: Arena<Memory> = Arena::new();
-        let id: MemoryId = arena.next_id();
+        let id: MemoryId = generate_id();
         let actual: Option<&Export> = module.exports.get_exported_memory(id);
         assert!(actual.is_none());
     }
@@ -326,8 +324,7 @@ mod tests {
     #[test]
     fn get_exported_global() {
         let mut module = Module::default();
-        let arena: Arena<Global> = Arena::new();
-        let id: GlobalId = arena.next_id();
+        let id: GlobalId = generate_id();
         module.exports.add("dummy", id);
 
         let actual: Option<&Export> = module.exports.get_exported_global(id);
@@ -343,8 +340,7 @@ mod tests {
     #[test]
     fn get_exported_global_should_return_none_for_unknown_global_id() {
         let module = Module::default();
-        let arena: Arena<Global> = Arena::new();
-        let id: GlobalId = arena.next_id();
+        let id: GlobalId = generate_id();
         let actual: Option<&Export> = module.exports.get_exported_global(id);
         assert!(actual.is_none());
     }

--- a/src/module/exports.rs
+++ b/src/module/exports.rs
@@ -274,7 +274,7 @@ mod tests {
     }
 
     #[test]
-    fn get_exported_table_should_return_non_for_unknown_table_id() {
+    fn get_exported_table_should_return_none_for_unknown_table_id() {
         let module = Module::default();
         let id: TableId = always_the_same_id();
         let actual: Option<&Export> = module.exports.get_exported_table(id);

--- a/src/module/exports.rs
+++ b/src/module/exports.rs
@@ -1,11 +1,11 @@
 //! Exported items in a wasm module.
 
 use crate::emit::{Emit, EmitContext, Section};
+use crate::map::IdHashMap;
 use crate::parse::IndicesToIds;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
+use crate::{Function, Global, Memory, Table};
 use crate::{FunctionId, GlobalId, MemoryId, Module, Result, TableId};
-
-use std::collections::HashMap;
 
 /// The id of an export.
 pub type ExportId = Id<Export>;
@@ -51,10 +51,10 @@ pub enum ExportItem {
 pub struct ModuleExports {
     /// The arena containing this module's exports.
     arena: TombstoneArena<Export>,
-    fn_id_to_export_id: HashMap<FunctionId, ExportId>,
-    tbl_id_to_export_id: HashMap<TableId, ExportId>,
-    mem_id_to_export_id: HashMap<MemoryId, ExportId>,
-    global_id_to_export_id: HashMap<GlobalId, ExportId>,
+    fn_id_to_export_id: IdHashMap<Function, ExportId>,
+    tbl_id_to_export_id: IdHashMap<Table, ExportId>,
+    mem_id_to_export_id: IdHashMap<Memory, ExportId>,
+    global_id_to_export_id: IdHashMap<Global, ExportId>,
 }
 
 impl ModuleExports {

--- a/src/module/exports.rs
+++ b/src/module/exports.rs
@@ -68,14 +68,6 @@ impl ModuleExports {
         &mut self.arena[id]
     }
 
-    fn get_safe(&self, id: ExportId) -> Option<&Export> {
-        self.arena.get(id)
-    }
-
-    fn get_mut_safe(&mut self, id: ExportId) -> Option<&mut Export> {
-        self.arena.get_mut(id)
-    }
-
     /// Delete an export entry from this module.
     pub fn delete(&mut self, id: ExportId) {
         self.remove_mapping(id);
@@ -120,43 +112,33 @@ impl ModuleExports {
     }
 
     fn remove_mapping(&mut self, id: ExportId) -> Option<ExportId> {
-        match self.get_mut_safe(id) {
-            Some(export) => match export.item {
-                ExportItem::Function(f) => self.fn_id_to_export_id.remove(&f),
-                ExportItem::Table(t) => self.tbl_id_to_export_id.remove(&t),
-                ExportItem::Memory(m) => self.mem_id_to_export_id.remove(&m),
-                ExportItem::Global(g) => self.global_id_to_export_id.remove(&g),
-            },
-            None => None,
+        let export = self.get_mut(id); // can throw
+        match export.item {
+            ExportItem::Function(f) => self.fn_id_to_export_id.remove(&f),
+            ExportItem::Table(t) => self.tbl_id_to_export_id.remove(&t),
+            ExportItem::Memory(m) => self.mem_id_to_export_id.remove(&m),
+            ExportItem::Global(g) => self.global_id_to_export_id.remove(&g),
         }
     }
 
     /// Get a reference to a function export given its function id.
     pub fn get_exported_func(&self, f: FunctionId) -> Option<&Export> {
-        self.fn_id_to_export_id
-            .get(&f)
-            .and_then(|id| self.get_safe(*id))
+        self.fn_id_to_export_id.get(&f).map(|id| self.get(*id)) // self.get can throw
     }
 
     /// Get a reference to a table export given its table id.
     pub fn get_exported_table(&self, t: TableId) -> Option<&Export> {
-        self.tbl_id_to_export_id
-            .get(&t)
-            .and_then(|id| self.get_safe(*id))
+        self.tbl_id_to_export_id.get(&t).map(|id| self.get(*id)) // self.get can throw
     }
 
     /// Get a reference to a memory export given its export id.
     pub fn get_exported_memory(&self, m: MemoryId) -> Option<&Export> {
-        self.mem_id_to_export_id
-            .get(&m)
-            .and_then(|id| self.get_safe(*id))
+        self.mem_id_to_export_id.get(&m).map(|id| self.get(*id)) // self.get can throw
     }
 
     /// Get a reference to a global export given its global id.
     pub fn get_exported_global(&self, g: GlobalId) -> Option<&Export> {
-        self.global_id_to_export_id
-            .get(&g)
-            .and_then(|id| self.get_safe(*id))
+        self.global_id_to_export_id.get(&g).map(|id| self.get(*id)) // self.get can throw
     }
 }
 


### PR DESCRIPTION
See #113 
## TODO:
- [x] Make sure updates via `ModuleExports::iter_mut()` get reflected in the arena (an issue with IdHashMap's not being updated)
- [x] Make sure there are no other ways to remove exports except `ModuleExports::delete`
- [x] Add `FunctionId` test case
- [x] Add `TableId` test case
- [x] Add `MemoryId` test case
- [x] Add `GlobalId` test case