### PR TITLE
Add support for `atomic.fence` instruction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ leb128 = "0.2.3"
 log = "0.4"
 rayon = { version = "1.0.3", optional = true }
 walrus-macro = { path = './crates/macro', version = '=0.10.0' }
-wasmparser = "0.34"
+wasmparser = "0.35"
 
 [features]
 parallel = ['rayon', 'id-arena/rayon']

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -384,6 +384,9 @@ pub enum Instr {
         sixty_four: bool,
     },
 
+    /// The `atomic.fence` instruction
+    AtomicFence {},
+
     /// `table.get`
     TableGet {
         /// The table we're fetching from.
@@ -1033,6 +1036,7 @@ impl Instr {
             | Instr::V128Swizzle(..)
             | Instr::V128Shuffle(..)
             | Instr::LoadSplat(..)
+            | Instr::AtomicFence(..)
             | Instr::Drop(..) => false,
         }
     }

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -716,6 +716,12 @@ impl<'instr> Visitor<'instr> for Emit<'_, '_> {
                 self.memarg(e.memory, &e.arg);
             }
 
+            AtomicFence(_e) => {
+                self.encoder.byte(0xfe);
+                self.encoder.byte(0x03);
+                self.encoder.byte(0x00);
+            }
+
             TableGet(e) => {
                 self.encoder.byte(0x25);
                 let idx = self.indices.get_table_index(e.table);

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -836,6 +836,13 @@ fn validate_instruction(ctx: &mut ValidationContext, inst: Operator) -> Result<(
             store(ctx, memarg, I64, StoreKind::I64_32 { atomic: false })?
         }
 
+        Operator::Fence { flags } => {
+            if flags != 0 {
+                bail!("fence with nonzero flags not supported yet");
+            }
+            ctx.alloc_instr(AtomicFence { });
+        }
+
         Operator::I32AtomicLoad { memarg } => {
             load(ctx, memarg, I32, LoadKind::I32 { atomic: true })?
         }


### PR DESCRIPTION
Recently added to the threads spec and support added in wasmparser!