### PR TITLE
Disable `derive` feature of `failure`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "benches/benches.rs"
 harness = false
 
 [dependencies]
-failure = "0.1.2"
+failure = { version = "0.1.2", default-features = false, features = ['std'] }
 id-arena = "2.2.1"
 leb128 = "0.2.3"
 log = "0.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types and utilities.
 
+use std::fmt;
 pub use failure::Error;
-use failure::*;
 
 /// Either `Ok(T)` or `Err(failure::Error)`.
 pub type Result<T> = ::std::result::Result<T, failure::Error>;
@@ -10,9 +10,20 @@ pub type Result<T> = ::std::result::Result<T, failure::Error>;
 ///
 /// Just an enum with no further information. Extra diagnostics are attached via
 /// failure's `context` method.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ErrorKind {
     /// Given invalid input wasm.
-    #[fail(display = "The input WebAssembly is invalid")]
     InvalidWasm,
 }
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ErrorKind::InvalidWasm => {
+                "The input WebAssembly is invalid".fmt(f)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ErrorKind {}


### PR DESCRIPTION
No need for us to build it as a dependency of `walrus` since our error
is so small! Ideally this will help trim our dependency graph slightly
and make builds a bit faster.