### PR TITLE
Fixing errors reported by `cargo clippy`

### DIFF
--- a/src/module/elements.rs
+++ b/src/module/elements.rs
@@ -76,7 +76,7 @@ impl Module {
             let segment = segment?;
 
             match segment.kind {
-                wasmparser::ElementKind::Passive(ty) => {
+                wasmparser::ElementKind::Passive(_) => {
                     bail!("passive element segments not supported yet");
                 }
                 wasmparser::ElementKind::Active {

--- a/src/module/elements.rs
+++ b/src/module/elements.rs
@@ -77,7 +77,6 @@ impl Module {
 
             match segment.kind {
                 wasmparser::ElementKind::Passive(ty) => {
-                    drop(ty);
                     bail!("passive element segments not supported yet");
                 }
                 wasmparser::ElementKind::Active {
@@ -222,9 +221,8 @@ impl Emit for ModuleElements {
         // may want to sort this more intelligently in the future. Otherwise
         // emitting a segment here is in general much simpler than above as we
         // know there are no holes.
-        for (id, segment) in self.arena.iter() {
+        for (id, _) in self.arena.iter() {
             cx.indices.push_element(id);
-            drop((id, segment));
             // TODO: sync this with the upstream spec
             panic!(
                 "encoding a passive element segment requires either \


### PR DESCRIPTION
removing unnecessary `drop` calls that clippy reported as errors

See: #125