### PR TITLE
Add a test for an invalid, result-producing `if` with no `else`

### DIFF
--- a/crates/tests/tests/invalid.rs
+++ b/crates/tests/tests/invalid.rs
@@ -10,8 +10,14 @@ fn run(wat: &Path) -> Result<(), failure::Error> {
     let wasm = walrus_tests_utils::wat2wasm(wat, &["--no-check"])?;
 
     // NB: reading the module will do the validation.
-    if let Ok(_) = walrus::Module::from_buffer(&wasm) {
-        failure::bail!("expected {} to be invalid, but it was valid", wat.display());
+    match walrus::Module::from_buffer(&wasm) {
+        Err(e) => {
+            eprintln!("Got error, as expected:");
+            for c in e.iter_chain() {
+                eprintln!("  - {}", c);
+            }
+        }
+        Ok(_) => failure::bail!("expected {} to be invalid, but it was valid", wat.display()),
     }
 
     Ok(())

--- a/crates/tests/tests/invalid/if-with-no-else.wat
+++ b/crates/tests/tests/invalid/if-with-no-else.wat
@@ -1,0 +1,12 @@
+(module
+  (func (export "f") (param i32) (result i32)
+    (local.get 0)
+    (if (result i32)
+      (then (i32.const 1))
+      ;; Note: since the `if` block is supposed to produce a result, we need an
+      ;; `else` here to produce that result if the condition is false.
+      ;;
+      ;; (else (i32.const 2))
+    )
+  )
+)


### PR DESCRIPTION
Wasn't sure that we correctly handled this case, but it turns out we do :)

Worth adding the test anyways (also manually checked that it fails if you uncomment the `else`).