### PR TITLE
Switch from `failure` to `anyhow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "benches/benches.rs"
 harness = false
 
 [dependencies]
-failure = { version = "0.1.5", default-features = false, features = ['std'] }
+anyhow = "1.0"
 id-arena = "2.2.1"
 leb128 = "0.2.4"
 log = "0.4.8"

--- a/crates/fuzz-utils/Cargo.toml
+++ b/crates/fuzz-utils/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 rand = { version = "0.7.0", features = ['small_rng'] }
 tempfile = "3.1.0"
-failure = "0.1.5"
+anyhow = "1.0"
 env_logger = "0.7.0"
 
 [dependencies.walrus]

--- a/crates/fuzz-utils/src/lib.rs
+++ b/crates/fuzz-utils/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(missing_docs)]
 
-use failure::ResultExt;
+use anyhow::Context;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::cmp;
 use std::fmt;
@@ -12,8 +12,8 @@ use std::path::Path;
 use std::time;
 use walrus_tests_utils::{wasm_interp, wat2wasm};
 
-/// `Ok(T)` or a `Err(failure::Error)`
-pub type Result<T> = std::result::Result<T, failure::Error>;
+/// `Ok(T)` or a `Err(anyhow::Error)`
+pub type Result<T> = std::result::Result<T, anyhow::Error>;
 
 #[derive(Copy, Clone, Debug)]
 enum ValType {
@@ -139,7 +139,7 @@ where
     pub fn run_one(&mut self) -> Result<()> {
         let wat = self.gen_wat();
         self.test_wat(&wat)
-            .with_context(|_| format!("wat = {}", wat))?;
+            .with_context(|| format!("wat = {}", wat))?;
         Ok(())
     }
 
@@ -436,12 +436,9 @@ impl TestCaseGenerator for WasmOptTtf {
     }
 }
 
-/// Print a `failure::Error` with its chain.
-pub fn print_err(e: &failure::Error) {
-    eprintln!("Error:");
-    for c in e.iter_chain() {
-        eprintln!("  - {}", c);
-    }
+/// Print a `anyhow::Error` with its chain.
+pub fn print_err(e: &anyhow::Error) {
+    eprintln!("Error: {:?}", e);
 }
 
 #[cfg(test)]

--- a/crates/tests-utils/Cargo.toml
+++ b/crates/tests-utils/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 tempfile = "3.1.0"
-failure = "0.1.5"
+anyhow = "1.0"

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 walkdir = "2.2.9"
 
 [dev-dependencies]
-failure = "0.1.5"
+anyhow = "1.0"
 walrus = { path = "../.." }
 walrus-tests-utils = { path = "../tests-utils" }
 tempfile = "3.1.0"

--- a/crates/tests/tests/function_imports.rs
+++ b/crates/tests/tests/function_imports.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use walrus_tests_utils::wat2wasm;
 
-fn run(wat_path: &Path) -> Result<(), failure::Error> {
+fn run(wat_path: &Path) -> Result<(), anyhow::Error> {
     static INIT_LOGS: std::sync::Once = std::sync::Once::new();
     INIT_LOGS.call_once(|| {
         env_logger::init();

--- a/crates/tests/tests/invalid.rs
+++ b/crates/tests/tests/invalid.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Once;
 
-fn run(wat: &Path) -> Result<(), failure::Error> {
+fn run(wat: &Path) -> Result<(), anyhow::Error> {
     static INIT_LOGS: Once = Once::new();
     INIT_LOGS.call_once(|| {
         env_logger::init();
@@ -12,12 +12,9 @@ fn run(wat: &Path) -> Result<(), failure::Error> {
     // NB: reading the module will do the validation.
     match walrus::Module::from_buffer(&wasm) {
         Err(e) => {
-            eprintln!("Got error, as expected:");
-            for c in e.iter_chain() {
-                eprintln!("  - {}", c);
-            }
+            eprintln!("Got error, as expected: {:?}", e);
         }
-        Ok(_) => failure::bail!("expected {} to be invalid, but it was valid", wat.display()),
+        Ok(_) => anyhow::bail!("expected {} to be invalid, but it was valid", wat.display()),
     }
 
     Ok(())

--- a/crates/tests/tests/round_trip.rs
+++ b/crates/tests/tests/round_trip.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::Path;
 use walrus_tests_utils::{wasm2wat, wat2wasm};
 
-fn run(wat_path: &Path) -> Result<(), failure::Error> {
+fn run(wat_path: &Path) -> Result<(), anyhow::Error> {
     static INIT_LOGS: std::sync::Once = std::sync::Once::new();
     INIT_LOGS.call_once(|| {
         env_logger::init();

--- a/crates/tests/tests/spec-tests.rs
+++ b/crates/tests/tests/spec-tests.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -10,7 +10,7 @@ struct Test {
     commands: Vec<serde_json::Value>,
 }
 
-fn run(wast: &Path) -> Result<(), failure::Error> {
+fn run(wast: &Path) -> Result<(), anyhow::Error> {
     static INIT_LOGS: std::sync::Once = std::sync::Once::new();
     INIT_LOGS.call_once(|| {
         env_logger::init();
@@ -145,7 +145,7 @@ fn run(wast: &Path) -> Result<(), failure::Error> {
     Ok(())
 }
 
-fn run_spectest_interp(cwd: &Path, extra_args: &[&str]) -> Result<(), failure::Error> {
+fn run_spectest_interp(cwd: &Path, extra_args: &[&str]) -> Result<(), anyhow::Error> {
     let output = Command::new("spectest-interp")
         .current_dir(cwd)
         .arg("foo.json")

--- a/crates/tests/tests/valid.rs
+++ b/crates/tests/tests/valid.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::Path;
 use std::sync::Once;
 
-fn run(wat: &Path) -> Result<(), failure::Error> {
+fn run(wat: &Path) -> Result<(), anyhow::Error> {
     static INIT_LOGS: Once = Once::new();
     INIT_LOGS.call_once(|| {
         env_logger::init();

--- a/examples/round-trip.rs
+++ b/examples/round-trip.rs
@@ -1,21 +1,9 @@
 //! A small example which is primarily used to help benchmark walrus right now.
 
-use std::process;
-
-fn main() {
-    if let Err(e) = try_main() {
-        eprintln!("Error!");
-        for c in e.iter_chain() {
-            eprintln!("{}", c);
-        }
-        process::exit(1);
-    }
-}
-
-fn try_main() -> Result<(), failure::Error> {
+fn main() -> anyhow::Result<()> {
     env_logger::init();
     let a = std::env::args().nth(1).ok_or_else(|| {
-        failure::format_err!("must provide the input wasm file as the first argument")
+        anyhow::anyhow!("must provide the input wasm file as the first argument")
     })?;
     let m = walrus::Module::from_file(&a)?;
     let wasm = m.emit_wasm();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,10 @@
 //! Error types and utilities.
 
-pub use failure::Error;
+pub use anyhow::Error;
 use std::fmt;
 
 /// Either `Ok(T)` or `Err(failure::Error)`.
-pub type Result<T> = ::std::result::Result<T, failure::Error>;
+pub type Result<T> = ::std::result::Result<T, anyhow::Error>;
 
 /// A leaf wasm error type.
 ///

--- a/src/init_expr.rs
+++ b/src/init_expr.rs
@@ -4,7 +4,7 @@ use crate::emit::{Emit, EmitContext};
 use crate::ir::Value;
 use crate::parse::IndicesToIds;
 use crate::{GlobalId, Result};
-use failure::bail;
+use anyhow::bail;
 
 /// A constant which is produced in WebAssembly, typically used in global
 /// initializers or element/data offsets.

--- a/src/module/data.rs
+++ b/src/module/data.rs
@@ -5,7 +5,7 @@ use crate::ir::Value;
 use crate::parse::IndicesToIds;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
 use crate::{GlobalId, InitExpr, MemoryId, Module, Result, ValType};
-use failure::{bail, ResultExt};
+use anyhow::{bail, Context};
 
 /// A passive element segment identifier
 pub type DataId = Id<Data>;
@@ -217,7 +217,7 @@ impl Module {
                     memory.data_segments.insert(data.id);
 
                     let offset = InitExpr::eval(&init_expr, ids)
-                        .with_context(|_e| format!("in segment {}", i))?;
+                        .with_context(|| format!("in segment {}", i))?;
                     data.kind = DataKind::Active(ActiveData {
                         memory: memory_id,
                         location: match offset {

--- a/src/module/elements.rs
+++ b/src/module/elements.rs
@@ -5,7 +5,7 @@ use crate::ir::Value;
 use crate::parse::IndicesToIds;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
 use crate::{FunctionId, InitExpr, Module, Result, TableKind, ValType};
-use failure::{bail, ResultExt};
+use anyhow::{bail, Context};
 
 /// A passive element segment identifier
 pub type ElementId = Id<Element>;
@@ -92,7 +92,7 @@ impl Module {
                     };
 
                     let offset = InitExpr::eval(&init_expr, ids)
-                        .with_context(|_e| format!("in segment {}", i))?;
+                        .with_context(|| format!("in segment {}", i))?;
                     let functions = segment.items.get_items_reader()?.into_iter().map(|func| {
                         let func = func?;
                         ids.get_func(func)

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -12,7 +12,7 @@ use crate::parse::IndicesToIds;
 use crate::{
     Data, DataId, FunctionBuilder, FunctionId, Module, Result, TableKind, TypeId, ValType,
 };
-use failure::{bail, ResultExt};
+use anyhow::{bail, Context};
 use std::collections::BTreeMap;
 use wasmparser::Operator;
 
@@ -308,7 +308,7 @@ fn validate_instruction(ctx: &mut ValidationContext, inst: Operator) -> Result<(
 
     let mem_arg = |arg: &wasmparser::MemoryImmediate| -> Result<MemArg> {
         if arg.flags >= 32 {
-            failure::bail!("invalid alignment");
+            bail!("invalid alignment");
         }
         Ok(MemArg {
             align: 1 << (arg.flags as i32),

--- a/src/module/functions/mod.rs
+++ b/src/module/functions/mod.rs
@@ -11,7 +11,7 @@ use crate::parse::IndicesToIds;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
 use crate::ty::TypeId;
 use crate::ty::ValType;
-use failure::bail;
+use anyhow::bail;
 use std::cmp;
 
 #[cfg(feature = "parallel")]

--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -5,6 +5,7 @@ use crate::parse::IndicesToIds;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
 use crate::{FunctionId, FunctionTable, GlobalId, MemoryId, Result, TableId};
 use crate::{Module, TableKind, TypeId, ValType};
+use anyhow::bail;
 
 /// The id of an import.
 pub type ImportId = Id<Import>;
@@ -123,7 +124,7 @@ impl Module {
                 wasmparser::ImportSectionEntryType::Table(t) => {
                     let kind = match t.element_type {
                         wasmparser::Type::AnyFunc => TableKind::Function(FunctionTable::default()),
-                        _ => failure::bail!("invalid table type"),
+                        _ => bail!("invalid table type"),
                     };
                     let id = self.add_import_table(
                         entry.module,

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -35,7 +35,7 @@ pub use crate::module::tables::FunctionTable;
 pub use crate::module::tables::{ModuleTables, Table, TableId, TableKind};
 pub use crate::module::types::ModuleTypes;
 use crate::parse::IndicesToIds;
-use failure::{bail, ResultExt};
+use anyhow::{bail, Context};
 use std::fs;
 use std::mem;
 use std::path::Path;
@@ -189,7 +189,7 @@ impl Module {
                         }
                         "name" => section
                             .get_name_section_reader()
-                            .map_err(failure::Error::from)
+                            .map_err(anyhow::Error::from)
                             .and_then(|r| ret.parse_name_section(r, &indices)),
                         _ => {
                             log::debug!("parsing custom section `{}`", name);

--- a/src/module/tables.rs
+++ b/src/module/tables.rs
@@ -4,6 +4,7 @@ use crate::emit::{Emit, EmitContext, Section};
 use crate::parse::IndicesToIds;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
 use crate::{FunctionId, GlobalId, ImportId, Module, Result, ValType};
+use anyhow::bail;
 
 /// The id of a table.
 pub type TableId = Id<Table>;
@@ -179,7 +180,7 @@ impl ModuleTables {
             None => return Ok(None),
         };
         if tables.next().is_some() {
-            failure::bail!("module contains more than one function table");
+            bail!("module contains more than one function table");
         }
         Ok(Some(id))
     }
@@ -206,7 +207,7 @@ impl Module {
                 match t.element_type {
                     wasmparser::Type::AnyFunc => TableKind::Function(FunctionTable::default()),
                     wasmparser::Type::AnyRef => TableKind::Anyref(AnyrefTable::default()),
-                    _ => failure::bail!("invalid table type"),
+                    _ => bail!("invalid table type"),
                 },
             );
             ids.push_table(id);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,7 +1,7 @@
 use crate::map::IdHashMap;
 use crate::{DataId, ElementId, Function, FunctionId, GlobalId, Result};
 use crate::{LocalId, MemoryId, TableId, TypeId};
-use failure::bail;
+use anyhow::bail;
 
 /// Maps from old indices in the original Wasm binary to `walrus` IDs.
 ///

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -4,6 +4,7 @@ use crate::emit::{Emit, EmitContext};
 use crate::encode::Encoder;
 use crate::error::Result;
 use crate::tombstone_arena::Tombstone;
+use anyhow::bail;
 use id_arena::Id;
 use std::cmp::Ordering;
 use std::fmt;
@@ -166,7 +167,7 @@ impl ValType {
             wasmparser::Type::F64 => Ok(ValType::F64),
             wasmparser::Type::V128 => Ok(ValType::V128),
             wasmparser::Type::AnyRef => Ok(ValType::Anyref),
-            _ => failure::bail!("not a value type"),
+            _ => bail!("not a value type"),
         }
     }
 


### PR DESCRIPTION
This moves us back to `std::error::Error` compatibility and helps build
times since it doesn't rely on an older version of `syn`