### PR TITLE
Allow custom sections to specify gc roots

### DIFF
--- a/src/module/custom.rs
+++ b/src/module/custom.rs
@@ -1,5 +1,6 @@
 //! Working with custom sections.
 
+use crate::passes::Roots;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
 use crate::CodeTransform;
 use crate::IdsToIndices;
@@ -28,6 +29,16 @@ pub trait CustomSection: WalrusAny + Debug + Send + Sync {
     /// section's name, or the count of how many bytes are in the
     /// payload. `walrus` will handle these for you.
     fn data(&self, ids_to_indices: &IdsToIndices) -> Cow<[u8]>;
+
+    /// Add any core wasm roots to the provided `roots` argument.
+    ///
+    /// This function will add any referenced core wasm items into the `Roots`
+    /// array provided.
+    ///
+    /// The default provided method does nothing.
+    fn add_gc_roots(&self, roots: &mut Roots) {
+        drop(roots);
+    }
 
     /// Apply the given code transformations to this custom section.
     ///

--- a/src/passes/gc.rs
+++ b/src/passes/gc.rs
@@ -4,13 +4,13 @@
 //! internally and can be safely removed.
 
 use crate::map::IdHashSet;
-use crate::passes::Used;
+use crate::passes::used::Used;
 use crate::{ImportKind, Module};
 use id_arena::Id;
 
 /// Run GC passes over the module specified.
 pub fn run(m: &mut Module) {
-    let used = Used::new(m, m.exports.iter().map(|e| e.id()));
+    let used = Used::new(m);
 
     let mut unused_imports = Vec::new();
     for import in m.imports.iter() {

--- a/src/passes/mod.rs
+++ b/src/passes/mod.rs
@@ -3,4 +3,4 @@
 pub mod gc;
 mod used;
 pub mod validate;
-pub use self::used::Used;
+pub use self::used::Roots;


### PR DESCRIPTION
This commit adds APIs necessary to allow custom sections to reference
core wasm functions/memories/etc and provide gc roots into them. This is
intended to be used, for example, with wasm interface types.