### PR TITLE
Implement the reference types proposal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,9 @@ jobs:
       matrix:
         rust: [stable, beta, nightly]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
     - name: Install Rust
       run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - name: Install wabt

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -561,6 +561,12 @@ fn create_visit(variants: &[WalrusVariant]) -> impl quote::ToTokens {
                 // ...
             }
 
+            /// Visit `ElementId`
+            #[inline]
+            fn visit_element_id(&mut self, elem: &crate::ElementId) {
+                // ...
+            }
+
             /// Visit `Value`.
             #[inline]
             fn visit_value(&mut self, value: &crate::ir::Value) {
@@ -642,6 +648,12 @@ fn create_visit(variants: &[WalrusVariant]) -> impl quote::ToTokens {
             /// Visit `TypeId`
             #[inline]
             fn visit_type_id_mut(&mut self, ty: &mut crate::TypeId) {
+                // ...
+            }
+
+            /// Visit `ElementId`
+            #[inline]
+            fn visit_element_id_mut(&mut self, elem: &mut crate::ElementId) {
                 // ...
             }
 

--- a/crates/tests/tests/round_trip/elem-segments-1.wat
+++ b/crates/tests/tests/round_trip/elem-segments-1.wat
@@ -5,4 +5,11 @@
   (export "foo" (table 0))
   )
 
-;; CHECK: (elem (;0;) (i32.const 1) 0)
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func (;0;) (type 0))
+    (table (;0;) 1 funcref)
+    (export "foo" (table 0))
+    (elem (;0;) (i32.const 1) func 0))
+;)

--- a/crates/tests/tests/round_trip/elem-segments-2.wat
+++ b/crates/tests/tests/round_trip/elem-segments-2.wat
@@ -6,4 +6,12 @@
   (export "foo" (table 0))
   )
 
-;; CHECK: (elem (;0;) (i32.const 1) 0 0)
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func (;0;) (type 0))
+    (table (;0;) 1 funcref)
+    (export "foo" (table 0))
+    (elem (;0;) (i32.const 1) 0)
+    (elem (;1;) (i32.const 2) 0))
+;)

--- a/crates/tests/tests/round_trip/elem-segments-2.wat
+++ b/crates/tests/tests/round_trip/elem-segments-2.wat
@@ -12,6 +12,6 @@
     (func (;0;) (type 0))
     (table (;0;) 1 funcref)
     (export "foo" (table 0))
-    (elem (;0;) (i32.const 1) 0)
-    (elem (;1;) (i32.const 2) 0))
+    (elem (;0;) (i32.const 1) func 0)
+    (elem (;1;) (i32.const 2) func 0))
 ;)

--- a/crates/tests/tests/round_trip/elem-segments-3.wat
+++ b/crates/tests/tests/round_trip/elem-segments-3.wat
@@ -6,5 +6,12 @@
   (export "foo" (table 0))
   )
 
-;; CHECK: (elem (;0;) (i32.const 1) 0)
-;; NEXT:  (elem (;1;) (i32.const 3) 0)
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func (;0;) (type 0))
+    (table (;0;) 1 funcref)
+    (export "foo" (table 0))
+    (elem (;0;) (i32.const 1) func 0)
+    (elem (;1;) (i32.const 3) func 0))
+;)

--- a/crates/tests/tests/round_trip/keep-elem-segments.wat
+++ b/crates/tests/tests/round_trip/keep-elem-segments.wat
@@ -13,13 +13,14 @@
   (export "foo" (func 0))
   )
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func))
-;; NEXT:    (func (;0;) (type 0)
-;; NEXT:      i32.const 0
-;; NEXT:      call_indirect (type 0))
-;; NEXT:    (func (;1;) (type 0))
-;; NEXT:    (table (;0;) 1 1 funcref)
-;; NEXT:    (export "foo" (func 0))
-;; NEXT:    (elem (;0;) (i32.const 0) 1))
-
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func (;0;) (type 0)
+      i32.const 0
+      call_indirect (type 0))
+    (func (;1;) (type 0))
+    (table (;0;) 1 1 funcref)
+    (export "foo" (func 0))
+    (elem (;0;) (i32.const 0) func 1))
+;)

--- a/crates/tests/tests/round_trip/simd.wat
+++ b/crates/tests/tests/round_trip/simd.wat
@@ -502,12 +502,6 @@
    (func $i32x4_trunc_u_f32x4_sat (export "i32x4_trunc_u_f32x4_sat") (param v128) (result v128)
     local.get 0
     i32x4.trunc_sat_f32x4_u)
-   (func $i64x2_trunc_s_f64x2_sat (export "i64x2_trunc_s_f64x2_sat") (param v128) (result v128)
-    local.get 0
-    i64x2.trunc_sat_f64x2_s)
-   (func $i64x2_trunc_u_f64x2_sat (export "i64x2_trunc_u_f64x2_sat") (param v128) (result v128)
-    local.get 0
-    i64x2.trunc_sat_f64x2_u)
 
    (func $f32x4.convert_i32x4_s (export "f32x4.convert_i32x4_s") (param v128) (result v128)
     local.get 0
@@ -515,12 +509,6 @@
    (func $f32x4.convert_i32x4_u (export "f32x4.convert_i32x4_u") (param v128) (result v128)
     local.get 0
     f32x4.convert_i32x4_u)
-   (func $f64x2.convert_i64x2_s (export "f64x2.convert_i64x2_s") (param v128) (result v128)
-    local.get 0
-    f64x2.convert_i64x2_s)
-   (func $f64x2.convert_i64x2_u (export "f64x2.convert_i64x2_u") (param v128) (result v128)
-    local.get 0
-    f64x2.convert_i64x2_u)
 )
 
 (; CHECK-ALL:
@@ -1015,24 +1003,12 @@
     (func $i32x4_trunc_u_f32x4_sat (type 10) (param v128) (result v128)
       local.get 0
       i32x4.trunc_sat_f32x4_u)
-    (func $i64x2_trunc_s_f64x2_sat (type 10) (param v128) (result v128)
-      local.get 0
-      i64x2.trunc_sat_f64x2_s)
-    (func $i64x2_trunc_u_f64x2_sat (type 10) (param v128) (result v128)
-      local.get 0
-      i64x2.trunc_sat_f64x2_u)
     (func $f32x4.convert_i32x4_s (type 10) (param v128) (result v128)
       local.get 0
       f32x4.convert_i32x4_s)
     (func $f32x4.convert_i32x4_u (type 10) (param v128) (result v128)
       local.get 0
       f32x4.convert_i32x4_u)
-    (func $f64x2.convert_i64x2_s (type 10) (param v128) (result v128)
-      local.get 0
-      f64x2.convert_i64x2_s)
-    (func $f64x2.convert_i64x2_u (type 10) (param v128) (result v128)
-      local.get 0
-      f64x2.convert_i64x2_u)
     (func $v128.const (type 0) (result v128)
       v128.const i32x4 0x00000001 0x00000002 0x00000003 0x00000004)
     (memory (;0;) 0)
@@ -1164,10 +1140,6 @@
     (export "f64x2.max" (func $f64x2.max))
     (export "i32x4_trunc_s_f32x4_sat" (func $i32x4_trunc_s_f32x4_sat))
     (export "i32x4_trunc_u_f32x4_sat" (func $i32x4_trunc_u_f32x4_sat))
-    (export "i64x2_trunc_s_f64x2_sat" (func $i64x2_trunc_s_f64x2_sat))
-    (export "i64x2_trunc_u_f64x2_sat" (func $i64x2_trunc_u_f64x2_sat))
     (export "f32x4.convert_i32x4_s" (func $f32x4.convert_i32x4_s))
-    (export "f32x4.convert_i32x4_u" (func $f32x4.convert_i32x4_u))
-    (export "f64x2.convert_i64x2_s" (func $f64x2.convert_i64x2_s))
-    (export "f64x2.convert_i64x2_u" (func $f64x2.convert_i64x2_u)))
+    (export "f32x4.convert_i32x4_u" (func $f32x4.convert_i32x4_u)))
 ;)

--- a/crates/tests/tests/round_trip/table-init.wast
+++ b/crates/tests/tests/round_trip/table-init.wast
@@ -5,10 +5,12 @@
   (elem (global.get 0) 0)
   (export "x" (table 0)))
 
-;; CHECK: (module
-;; NEXT:    (type
-;; NEXT:    (import "x" "y" (global (;0;) i32))
-;; NEXT:    (func
-;; NEXT:    (table
-;; NEXT:    (export "x" (table 0))
-;; NEXT:    (elem (;0;) (global.get 0) 0))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (import "x" "y" (global (;0;) i32))
+    (func (;0;) (type 0))
+    (table (;0;) 1 funcref)
+    (export "x" (table 0))
+    (elem (;0;) (global.get 0) func 0))
+;)

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -281,7 +281,6 @@ impl DotNode for Table {
         fields.add_field(&[&format!("<b>Table {:?}</b>", self.id())]);
         fields.add_field(&["initial", &self.initial.to_string()]);
         fields.add_field(&["maximum", &format!("{:?}", self.maximum)]);
-        fields.add_field(&["kind", &format!("{:?}", self.kind)]);
         if self.import.is_some() {
             fields.add_field_with_port("import", "import");
         }
@@ -528,7 +527,9 @@ impl DotNode for Element {
 
     fn edges(&self, edges: &mut impl EdgeAggregator) {
         for m in self.members.iter() {
-            edges.add_edge(m);
+            if let Some(m) = m {
+                edges.add_edge(m);
+            }
         }
     }
 }

--- a/src/init_expr.rs
+++ b/src/init_expr.rs
@@ -3,7 +3,7 @@
 use crate::emit::{Emit, EmitContext};
 use crate::ir::Value;
 use crate::parse::IndicesToIds;
-use crate::{GlobalId, Result};
+use crate::{GlobalId, Result, FunctionId};
 use anyhow::bail;
 
 /// A constant which is produced in WebAssembly, typically used in global
@@ -14,6 +14,10 @@ pub enum InitExpr {
     Value(Value),
     /// A constant value referenced by the global specified
     Global(GlobalId),
+    /// A null reference
+    RefNull,
+    /// A function initializer
+    RefFunc(FunctionId),
 }
 
 impl InitExpr {
@@ -27,6 +31,8 @@ impl InitExpr {
             F64Const { value } => InitExpr::Value(Value::F64(f64::from_bits(value.bits()))),
             V128Const { value } => InitExpr::Value(Value::V128(v128_to_u128(&value))),
             GlobalGet { global_index } => InitExpr::Global(ids.get_global(global_index)?),
+            RefNull => InitExpr::RefNull,
+            RefFunc { function_index } => InitExpr::RefFunc(ids.get_func(function_index)?),
             _ => bail!("invalid constant expression"),
         };
         match reader.read()? {
@@ -46,6 +52,11 @@ impl Emit for InitExpr {
                 let idx = cx.indices.get_global_index(id);
                 cx.encoder.byte(0x23); // global.get
                 cx.encoder.u32(idx);
+            }
+            InitExpr::RefNull => cx.encoder.byte(0xd0), // ref.null
+            InitExpr::RefFunc(id) => {
+                cx.encoder.byte(0xd2); // ref.func
+                cx.encoder.u32(cx.indices.get_func_index(id));
             }
         }
         cx.encoder.byte(0x0b); // end

--- a/src/init_expr.rs
+++ b/src/init_expr.rs
@@ -3,7 +3,7 @@
 use crate::emit::{Emit, EmitContext};
 use crate::ir::Value;
 use crate::parse::IndicesToIds;
-use crate::{GlobalId, Result, FunctionId};
+use crate::{FunctionId, GlobalId, Result};
 use anyhow::bail;
 
 /// A constant which is produced in WebAssembly, typically used in global

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -9,8 +9,8 @@ pub use self::traversals::*;
 
 use crate::encode::Encoder;
 use crate::{
-    DataId, FunctionId, GlobalId, LocalFunction, MemoryId, ModuleTypes, TableId, TypeId, ValType,
-    ElementId,
+    DataId, ElementId, FunctionId, GlobalId, LocalFunction, MemoryId, ModuleTypes, TableId, TypeId,
+    ValType,
 };
 use id_arena::Id;
 use std::fmt;

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -10,6 +10,7 @@ pub use self::traversals::*;
 use crate::encode::Encoder;
 use crate::{
     DataId, FunctionId, GlobalId, LocalFunction, MemoryId, ModuleTypes, TableId, TypeId, ValType,
+    ElementId,
 };
 use id_arena::Id;
 use std::fmt;
@@ -555,6 +556,28 @@ pub enum Instr {
         /// The alignment and offset of this memory load
         #[walrus(skip_visit)]
         arg: MemArg,
+    },
+
+    /// `table.init`
+    TableInit {
+        /// The table we're copying into.
+        table: TableId,
+        /// The element we're getting items from.
+        elem: ElementId,
+    },
+
+    /// `elem.drop`
+    ElemDrop {
+        /// The elem segment to drop
+        elem: ElementId,
+    },
+
+    /// `table.copy`
+    TableCopy {
+        /// The source table
+        src: TableId,
+        /// The destination table
+        dst: TableId,
     },
 }
 
@@ -1177,6 +1200,9 @@ impl Instr {
             | Instr::V128Shuffle(..)
             | Instr::LoadSimd(..)
             | Instr::AtomicFence(..)
+            | Instr::TableInit(..)
+            | Instr::TableCopy(..)
+            | Instr::ElemDrop(..)
             | Instr::Drop(..) => false,
         }
     }

--- a/src/module/elements.rs
+++ b/src/module/elements.rs
@@ -3,7 +3,7 @@
 use crate::emit::{Emit, EmitContext, Section};
 use crate::parse::IndicesToIds;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
-use crate::{FunctionId, InitExpr, Module, Result, TableId, ValType, ir::Value};
+use crate::{ir::Value, FunctionId, InitExpr, Module, Result, TableId, ValType};
 use anyhow::{bail, Context};
 
 /// A passive element segment identifier

--- a/src/module/functions/local_function/context.rs
+++ b/src/module/functions/local_function/context.rs
@@ -241,12 +241,12 @@ fn impl_pop_operand_expected(
         (None, expected) => Ok(expected),
         (actual, None) => Ok(actual),
         (Some(actual), Some(expected)) => {
-            if actual != expected {
+            if !actual.is_subtype_of(expected) {
                 Err(ErrorKind::InvalidWasm)
                     .context(format!("expected type {}", expected))
                     .context(format!("found type {}", actual))
             } else {
-                Ok(Some(actual))
+                Ok(Some(expected))
             }
         }
     }

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -822,6 +822,20 @@ impl<'instr> Visitor<'instr> for Emit<'_, '_> {
                 }
                 self.memarg(e.memory, &e.arg);
             }
+            TableInit(e) => {
+                self.encoder.raw(&[0xfc, 0x0c]);
+                self.encoder.u32(self.indices.get_element_index(e.elem));
+                self.encoder.u32(self.indices.get_table_index(e.table));
+            }
+            TableCopy(e) => {
+                self.encoder.raw(&[0xfc, 0x0e]);
+                self.encoder.u32(self.indices.get_table_index(e.src));
+                self.encoder.u32(self.indices.get_table_index(e.dst));
+            }
+            ElemDrop(e) => {
+                self.encoder.raw(&[0xfc, 0x0d]);
+                self.encoder.u32(self.indices.get_element_index(e.elem));
+            }
         }
     }
 }

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -24,6 +24,7 @@ pub use crate::module::custom::{
 };
 pub use crate::module::data::{ActiveData, ActiveDataLocation, Data, DataId, DataKind, ModuleData};
 pub use crate::module::elements::{Element, ElementId, ModuleElements};
+pub use crate::module::elements::ElementKind;
 pub use crate::module::exports::{Export, ExportId, ExportItem, ModuleExports};
 pub use crate::module::functions::{Function, FunctionId, ModuleFunctions};
 pub use crate::module::functions::{FunctionKind, ImportedFunction, LocalFunction};
@@ -32,8 +33,7 @@ pub use crate::module::imports::{Import, ImportId, ImportKind, ModuleImports};
 pub use crate::module::locals::ModuleLocals;
 pub use crate::module::memories::{Memory, MemoryId, ModuleMemories};
 pub use crate::module::producers::ModuleProducers;
-pub use crate::module::tables::FunctionTable;
-pub use crate::module::tables::{ModuleTables, Table, TableId, TableKind};
+pub use crate::module::tables::{ModuleTables, Table, TableId};
 pub use crate::module::types::ModuleTypes;
 use crate::parse::IndicesToIds;
 use anyhow::{bail, Context};

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -23,8 +23,8 @@ pub use crate::module::custom::{
     UntypedCustomSectionId,
 };
 pub use crate::module::data::{ActiveData, ActiveDataLocation, Data, DataId, DataKind, ModuleData};
-pub use crate::module::elements::{Element, ElementId, ModuleElements};
 pub use crate::module::elements::ElementKind;
+pub use crate::module::elements::{Element, ElementId, ModuleElements};
 pub use crate::module::exports::{Export, ExportId, ExportItem, ModuleExports};
 pub use crate::module::functions::{Function, FunctionId, ModuleFunctions};
 pub use crate::module::functions::{FunctionKind, ImportedFunction, LocalFunction};

--- a/src/module/tables.rs
+++ b/src/module/tables.rs
@@ -1,10 +1,10 @@
 //! Tables within a wasm module.
 
 use crate::emit::{Emit, EmitContext, Section};
-use crate::parse::IndicesToIds;
 use crate::map::IdHashSet;
+use crate::parse::IndicesToIds;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
-use crate::{ImportId, Module, Result, ValType, Element};
+use crate::{Element, ImportId, Module, Result, ValType};
 use anyhow::bail;
 
 /// The id of a table.

--- a/src/module/tables.rs
+++ b/src/module/tables.rs
@@ -2,8 +2,9 @@
 
 use crate::emit::{Emit, EmitContext, Section};
 use crate::parse::IndicesToIds;
+use crate::map::IdHashSet;
 use crate::tombstone_arena::{Id, Tombstone, TombstoneArena};
-use crate::{FunctionId, GlobalId, ImportId, Module, Result, ValType};
+use crate::{ImportId, Module, Result, ValType, Element};
 use anyhow::bail;
 
 /// The id of a table.
@@ -17,61 +18,15 @@ pub struct Table {
     pub initial: u32,
     /// The maximum size of this table
     pub maximum: Option<u32>,
-    /// Which kind of table this is
-    pub kind: TableKind,
+    /// The type of the elements in this table
+    pub element_ty: ValType,
     /// Whether or not this table is imported, and if so what imports it.
     pub import: Option<ImportId>,
+    /// Active data segments that will be used to initialize this memory.
+    pub elem_segments: IdHashSet<Element>,
 }
 
 impl Tombstone for Table {}
-
-/// The kinds of tables that can exist
-#[derive(Debug)]
-pub enum TableKind {
-    /// A table of `anyfunc` functions.
-    ///
-    /// Contains the initialization list for this table, if any.
-    Function(FunctionTable),
-
-    /// A table of type `anyref` values
-    Anyref(AnyrefTable),
-}
-
-impl TableKind {
-    /// Unwrap `TableKind` to get inner `FunctionTable`. Panics if `TableKind` is anything other than `Function`
-    pub fn unwrap_function(&self) -> &FunctionTable {
-        match *self {
-            TableKind::Function(ref table) => table,
-            _ => panic!("not a Function"),
-        }
-    }
-
-    /// Unwrap `TableKind` to get inner `Anyref`. Panics if `TableKind` is anything other than `Anyref`
-    pub fn unwrap_anyref(&self) -> &AnyrefTable {
-        match *self {
-            TableKind::Anyref(ref anyref) => anyref,
-            _ => panic!("not an Anyref"),
-        }
-    }
-}
-
-/// Components of a table of functions (`anyfunc` table)
-#[derive(Debug, Default)]
-pub struct FunctionTable {
-    /// Layout of this function table that we know of, or those elements which
-    /// have constant initializers.
-    pub elements: Vec<Option<FunctionId>>,
-
-    /// Elements of this table which are relative to a global, typically
-    /// imported.
-    pub relative_elements: Vec<(GlobalId, Vec<Option<FunctionId>>)>,
-}
-
-/// Components of a table of `anyref`
-#[derive(Debug, Default)]
-pub struct AnyrefTable {
-    // currently intentionally empty
-}
 
 impl Table {
     /// Get this table's id.
@@ -82,12 +37,7 @@ impl Table {
 
 impl Emit for Table {
     fn emit(&self, cx: &mut EmitContext) {
-        match self.kind {
-            TableKind::Function(_) => {
-                cx.encoder.byte(0x70); // the `anyfunc` type
-            }
-            TableKind::Anyref(_) => ValType::Anyref.emit(&mut cx.encoder),
-        }
+        self.element_ty.emit(&mut cx.encoder);
         cx.encoder.byte(self.maximum.is_some() as u8);
         cx.encoder.u32(self.initial);
         if let Some(m) = self.maximum {
@@ -109,7 +59,7 @@ impl ModuleTables {
         &mut self,
         initial: u32,
         max: Option<u32>,
-        kind: TableKind,
+        element_ty: ValType,
         import: ImportId,
     ) -> TableId {
         let id = self.arena.next_id();
@@ -117,21 +67,23 @@ impl ModuleTables {
             id,
             initial,
             maximum: max,
-            kind,
+            element_ty,
             import: Some(import),
+            elem_segments: Default::default(),
         })
     }
 
     /// Construct a new table, that does not originate from any of the input
     /// wasm tables.
-    pub fn add_local(&mut self, initial: u32, max: Option<u32>, kind: TableKind) -> TableId {
+    pub fn add_local(&mut self, initial: u32, max: Option<u32>, element_ty: ValType) -> TableId {
         let id = self.arena.next_id();
         let id2 = self.arena.alloc(Table {
             id,
             initial,
             maximum: max,
-            kind,
+            element_ty,
             import: None,
+            elem_segments: Default::default(),
         });
         debug_assert_eq!(id, id2);
         id
@@ -171,12 +123,9 @@ impl ModuleTables {
     ///
     /// Returns an error if there are two function tables in this module
     pub fn main_function_table(&self) -> Result<Option<TableId>> {
-        let mut tables = self.iter().filter_map(|t| match t.kind {
-            TableKind::Function(_) => Some(t.id()),
-            _ => None,
-        });
+        let mut tables = self.iter().filter(|t| t.element_ty == ValType::Funcref);
         let id = match tables.next() {
-            Some(id) => id,
+            Some(t) => t.id(),
             None => return Ok(None),
         };
         if tables.next().is_some() {
@@ -204,11 +153,7 @@ impl Module {
             let id = self.tables.add_local(
                 t.limits.initial,
                 t.limits.maximum,
-                match t.element_type {
-                    wasmparser::Type::AnyFunc => TableKind::Function(FunctionTable::default()),
-                    wasmparser::Type::AnyRef => TableKind::Anyref(AnyrefTable::default()),
-                    _ => bail!("invalid table type"),
-                },
+                ValType::parse(&t.element_type)?,
             );
             ids.push_table(id);
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -60,7 +60,7 @@ define_push_get!(push_type, get_type, TypeId, types);
 define_push_get!(push_func, get_func, FunctionId, funcs);
 define_push_get!(push_global, get_global, GlobalId, globals);
 define_push_get!(push_memory, get_memory, MemoryId, memories);
-//define_push_get!(push_element, get_element, ElementId, elements);
+define_push_get!(push_element, get_element, ElementId, elements);
 define_push_get!(push_data, get_data, DataId, data);
 
 impl IndicesToIds {


### PR DESCRIPTION
This commit enables the `reference-types` and `bulk-memory-operations`
proposals from the upstream wasm spec test suite. This involved fully
implementing the reference types proposal, notably passive element
segments as well as a few table-related instructions. A summary of the
changes made here are:

* `TableCopy`, `TableInit`, and `ElemDrop` are now all implemented instructions.
* All element segments now live as an `Element` type rather than being
  embedded directly into a `Table`. This is because they all need an
  index to refer to in `ElemDrop` instructions and such.
* Type checking has been updated to handle subtyping
* The `Funcref` and `Nullref` value types have been added
* Tables now list their element type as a struct field
* Elements now participate in GC passes
* Global initializers are expanded with `ref.func` and `ref.null`