### PR TITLE
bump walrus-macro dep version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ id-arena = "2.2.1"
 leb128 = "0.2.4"
 log = "0.4.8"
 rayon = { version = "1.1.0", optional = true }
-walrus-macro = { path = './crates/macro', version = '=0.16.0' }
+walrus-macro = { path = './crates/macro', version = '=0.17.0' }
 wasmparser = "0.55.0"
 
 [features]


### PR DESCRIPTION
Not sure if `walrus-macro` version in `dependencies` should be bumped to `0.17.0`.  I encountered the same error as in #165 