### PR TITLE
More permissive parsing of the "name" section

### DIFF
--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -384,9 +384,9 @@ impl Module {
                         let naming = map.read()?;
                         match indices.get_func(naming.index) {
                             Ok(id) => self.funcs.get_mut(id).name = Some(naming.name.to_string()),
-                            // It looks like emscripten doesn't properly GC the
-                            // name section under certain circumstances, so
-                            // nonexistent symbols can be present.
+                            // If some tool fails to GC function names properly,
+                            // it doesn't really hurt anything to ignore the
+                            // broken references and keep going.
                             Err(e) => warn!("in name section: {}", e),
                         }
                     }
@@ -412,6 +412,9 @@ impl Module {
                                 Ok(id) => {
                                     self.locals.get_mut(id).name = Some(naming.name.to_string())
                                 }
+                                // It looks like emscripten leaves broken
+                                // function references in the locals subsection
+                                // sometimes.
                                 Err(e) => warn!("in name section: {}", e),
                             }
                         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -73,11 +73,14 @@ impl IndicesToIds {
 
     /// Gets the ID for a particular index
     pub fn get_local(&self, function: FunctionId, index: u32) -> Result<LocalId> {
-        let ret = self
-            .locals
-            .get(&function)
-            .and_then(|list| list.get(index as usize));
-        match ret {
+        let locals = match self.locals.get(&function) {
+            Some(x) => x,
+            None => bail!(
+                "function index `{}` is out of bounds for local",
+                function.index()
+            ),
+        };
+        match locals.get(index as usize) {
             Some(x) => Ok(*x),
             None => bail!(
                 "index `{}` in function `{}` is out of bounds for local",

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -79,7 +79,11 @@ impl IndicesToIds {
             .and_then(|list| list.get(index as usize));
         match ret {
             Some(x) => Ok(*x),
-            None => bail!("index `{}` is out of bounds for local", index,),
+            None => bail!(
+                "index `{}` in function `{}` is out of bounds for local",
+                index,
+                function.index(),
+            ),
         }
     }
 }


### PR DESCRIPTION
I've been working on getting DWARF debug symbols setup for a very large C++/emscripten app. Sentry.io's [symbolic](https://github.com/getsentry/symbolic) project is currently barfing on the bundle. Doing some investigation, I found that walrus was failing to parse the "name" custom section because emscripten appears to be:
1. leaving in symbols for deleted functions
2. implementing a bit of the https://github.com/WebAssembly/extended-name-section proposal

Since the "name" section is just debug info, I figured it would make sense to do more of a best-effort parsing, where we skip over any malformed entries instead of bailing out of the entire section on error. Looking at the `parse_name_section` function, there is already one such case (empty local names).

Originally I just added a bunch of match statements. But noticing there was a common pattern, I wrote a macro. If the macro is too scary, I can go back to the more verbose version.

