### PR TITLE
bump wasmparser to version 0.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ leb128 = "0.2.4"
 log = "0.4.8"
 rayon = { version = "1.1.0", optional = true }
 walrus-macro = { path = './crates/macro', version = '=0.19.0' }
-wasmparser = "0.77.0"
+wasmparser = "0.78.0"
 
 [features]
 parallel = ['rayon', 'id-arena/rayon']

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -420,6 +420,7 @@ impl Module {
                         }
                     }
                 }
+                wasmparser::Name::Unknown { ty, .. } => warn!("unknown name subsection {}", ty),
             }
         }
         Ok(())


### PR DESCRIPTION
This is a fairly minor change. At least from where I sit, it is mainly related to the permissive name section parsing added in #209.