### PR TITLE
fix test on Windows and fix CI failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ crates/tests/tests/**/*.out.wasm
 crates/tests/tests/**/*.out.wat
 
 .vscode
+.DS_Store

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = { version = "1.0.40", features = ['preserve_order'] }
 tempfile = "3.1.0"
 walrus = { path = "../.." }
 walrus-tests-utils = { path = "../tests-utils" }
-wasmprinter = "0.2.25"
+wasmprinter = "=0.2.25"
 wat = "1.0.36"
 
 [features]

--- a/crates/tests/build.rs
+++ b/crates/tests/build.rs
@@ -54,7 +54,7 @@ fn generate_tests(name: &str) {
             ""
         };
         tests.push_str(&format!(
-            "#[test] {} fn {}() {{ walrus_tests_utils::handle(run(\"{}\".as_ref())); }}\n",
+            "#[test] {} fn {}() {{ walrus_tests_utils::handle(run({:?}.as_ref())); }}\n",
             ignore_test,
             test_name,
             path.display(),


### PR DESCRIPTION
It fixes the path escape issue on Windows.

And by using a fixed version number for wasmprinter, it fixes the CI failure that has been there for some days.