### PR TITLE
Fix failing round-trip tests

### DIFF
--- a/crates/tests/tests/round_trip/anyref1.wat
+++ b/crates/tests/tests/round_trip/anyref1.wat
@@ -10,6 +10,8 @@
     (import "x" "y" (func (;0;) (type 0)))
     (func (;1;) (type 0) (param externref)
       local.get 0
-      call 0)
-    (export "a" (func 1)))
+      call 0
+    )
+    (export "a" (func 1))
+  )
 ;)

--- a/crates/tests/tests/round_trip/anyref2.wat
+++ b/crates/tests/tests/round_trip/anyref2.wat
@@ -9,7 +9,9 @@
     (type (;0;) (func (param i32) (result externref)))
     (func (;0;) (type 0) (param i32) (result externref)
       local.get 0
-      table.get 0)
+      table.get 0
+    )
     (table (;0;) 1 externref)
-    (export "a" (func 0)))
+    (export "a" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/anyref3.wat
+++ b/crates/tests/tests/round_trip/anyref3.wat
@@ -16,8 +16,10 @@
       local.get 0
       call_indirect (type 0)
       local.get 0
-      table.get 1)
+      table.get 1
+    )
     (table (;0;) 1 funcref)
     (table (;1;) 1 externref)
-    (export "a" (func 0)))
+    (export "a" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/atomic.wat
+++ b/crates/tests/tests/round_trip/atomic.wat
@@ -61,7 +61,9 @@
       i32.add
       i32.add
       i32.add
-      drop)
+      drop
+    )
     (memory (;0;) 1 1 shared)
-    (export "atomics" (func 0)))
+    (export "atomics" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/block.wat
+++ b/crates/tests/tests/round_trip/block.wat
@@ -15,19 +15,24 @@
     end)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      i32.const 0
-;; NEXT:      drop
-;; NEXT:      block  ;; label = @1
-;; NEXT:        i32.const 1
-;; NEXT:        drop
-;; NEXT:      end
-;; NEXT:      i32.const 2)
-;; NEXT:    (func (;1;) (type 0) (result i32)
-;; NEXT:      block
-;; NEXT:        i32.const 0
-;; NEXT:      end)
-;; NEXT:    (export "foo" (func 1))
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 0
+      drop
+      block  ;; label = @1
+        i32.const 1
+        drop
+      end
+      i32.const 2
+    )
+    (func (;1;) (type 0) (result i32)
+      block (result i32)  ;; label = @1
+        i32.const 0
+      end
+    )
+    (export "foo" (func 1))
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/block.wat
+++ b/crates/tests/tests/round_trip/block.wat
@@ -21,14 +21,14 @@
     (func $f (;0;) (type 0) (result i32)
       i32.const 0
       drop
-      block  ;; label = @1
+      block ;; label = @1
         i32.const 1
         drop
       end
       i32.const 2
     )
     (func (;1;) (type 0) (result i32)
-      block (result i32)  ;; label = @1
+      block (result i32) ;; label = @1
         i32.const 0
       end
     )

--- a/crates/tests/tests/round_trip/br_table.wat
+++ b/crates/tests/tests/round_trip/br_table.wat
@@ -16,20 +16,24 @@
     i32.const 100)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func $f (type 0) (param i32) (result i32)
-;; NEXT:      block  ;; label = @1
-;; NEXT:        block  ;; label = @2
-;; NEXT:          block  ;; label = @3
-;; NEXT:            local.get 0
-;; NEXT:            br_table 0 (;@3;) 1 (;@2;) 2 (;@1;)
-;; NEXT:          end
-;; NEXT:          i32.const 300
-;; NEXT:          return
-;; NEXT:        end
-;; NEXT:        i32.const 200
-;; NEXT:        return
-;; NEXT:      end
-;; NEXT:      i32.const 100)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (param i32) (result i32)))
+    (func $f (;0;) (type 0) (param i32) (result i32)
+      block  ;; label = @1
+        block  ;; label = @2
+          block  ;; label = @3
+            local.get 0
+            br_table 0 (;@3;) 1 (;@2;) 2 (;@1;)
+          end
+          i32.const 300
+          return
+        end
+        i32.const 200
+        return
+      end
+      i32.const 100
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/br_table.wat
+++ b/crates/tests/tests/round_trip/br_table.wat
@@ -20,9 +20,9 @@
   (module
     (type (;0;) (func (param i32) (result i32)))
     (func $f (;0;) (type 0) (param i32) (result i32)
-      block  ;; label = @1
-        block  ;; label = @2
-          block  ;; label = @3
+      block ;; label = @1
+        block ;; label = @2
+          block ;; label = @3
             local.get 0
             br_table 0 (;@3;) 1 (;@2;) 2 (;@1;)
           end

--- a/crates/tests/tests/round_trip/bulk-memory.wat
+++ b/crates/tests/tests/round_trip/bulk-memory.wat
@@ -40,10 +40,12 @@
       i32.const 1
       i32.const 2
       i32.const 3
-      memory.fill)
+      memory.fill
+    )
     (memory (;0;) 1)
     (export "a" (func 0))
     (data (;0;) "A")
     (data (;1;) (i32.const 0) "b")
-    (data (;2;) "C"))
+    (data (;2;) "C")
+  )
 ;)

--- a/crates/tests/tests/round_trip/call-two-params.wat
+++ b/crates/tests/tests/round_trip/call-two-params.wat
@@ -8,6 +8,17 @@
     )
   )
 )
-;; CHECK: i32.const 1
-;; NEXT:  f32.const
-;; NEXT:  call $print_i32_f32
+
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (type (;1;) (func (param i32 f32)))
+    (import "spectest" "print_i32_f32" (func $print_i32_f32 (;0;) (type 1)))
+    (func (;1;) (type 0)
+      i32.const 1
+      f32.const 0x1.5p+5 (;=42;)
+      call $print_i32_f32
+    )
+    (export "print32" (func 1))
+  )
+;)

--- a/crates/tests/tests/round_trip/call.wat
+++ b/crates/tests/tests/round_trip/call.wat
@@ -5,10 +5,13 @@
     (call 0))
   (export "g" (func $g)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (import "env" "f" (func (;0;) (type 0)))
-;; NEXT:    (func $g (type 0) (result i32)
-;; NEXT:      call 0)
-;; NEXT:    (export "g" (func $g)))
-
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (import "env" "f" (func (;0;) (type 0)))
+    (func $g (;1;) (type 0) (result i32)
+      call 0
+    )
+    (export "g" (func $g))
+  )
+;)

--- a/crates/tests/tests/round_trip/call_2.wat
+++ b/crates/tests/tests/round_trip/call_2.wat
@@ -8,10 +8,14 @@
     (call 0))
   (export "g" (func $g)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (import "env" "f" (func (;0;) (type 0)))
-;; NEXT:    (func $g (type 0) (param i32) (result i32)
-;; NEXT:      local.get 0
-;; NEXT:      call 0)
-;; NEXT:    (export "g" (func $g)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (param i32) (result i32)))
+    (import "env" "f" (func (;0;) (type 0)))
+    (func $g (;1;) (type 0) (param i32) (result i32)
+      local.get 0
+      call 0
+    )
+    (export "g" (func $g))
+  )
+;)

--- a/crates/tests/tests/round_trip/const.wat
+++ b/crates/tests/tests/round_trip/const.wat
@@ -4,8 +4,12 @@
     i32.const 42)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 42
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/count-to-ten.wat
+++ b/crates/tests/tests/round_trip/count-to-ten.wat
@@ -9,20 +9,24 @@
     i32.const 10)
   (export "count_to_ten" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      (local i32)
-;; NEXT:      i32.const 9
-;; NEXT:      local.set 0
-;; NEXT:      loop  ;; label = @1
-;; NEXT:        local.get 0
-;; NEXT:        i32.eqz
-;; NEXT:        br_if 0 (;@1;)
-;; NEXT:        local.get 0
-;; NEXT:        i32.const 1
-;; NEXT:        i32.add
-;; NEXT:        local.set 0
-;; NEXT:      end
-;; NEXT:      i32.const 10)
-;; NEXT:    (export "count_to_ten" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      (local i32)
+      i32.const 9
+      local.set 0
+      loop  ;; label = @1
+        local.get 0
+        i32.eqz
+        br_if 0 (;@1;)
+        local.get 0
+        i32.const 1
+        i32.add
+        local.set 0
+      end
+      i32.const 10
+    )
+    (export "count_to_ten" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/count-to-ten.wat
+++ b/crates/tests/tests/round_trip/count-to-ten.wat
@@ -16,7 +16,7 @@
       (local i32)
       i32.const 9
       local.set 0
-      loop  ;; label = @1
+      loop ;; label = @1
         local.get 0
         i32.eqz
         br_if 0 (;@1;)

--- a/crates/tests/tests/round_trip/drop.wat
+++ b/crates/tests/tests/round_trip/drop.wat
@@ -4,9 +4,13 @@
     (drop (i32.const 42)))
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func))
-;; NEXT:    (func $f (type 0)
-;; NEXT:      i32.const 42
-;; NEXT:      drop)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func $f (;0;) (type 0)
+      i32.const 42
+      drop
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/elem-segments-1.wat
+++ b/crates/tests/tests/round_trip/elem-segments-1.wat
@@ -11,5 +11,6 @@
     (func (;0;) (type 0))
     (table (;0;) 1 funcref)
     (export "foo" (table 0))
-    (elem (;0;) (i32.const 1) func 0))
+    (elem (;0;) (i32.const 1) func 0)
+  )
 ;)

--- a/crates/tests/tests/round_trip/elem-segments-2.wat
+++ b/crates/tests/tests/round_trip/elem-segments-2.wat
@@ -13,5 +13,6 @@
     (table (;0;) 1 funcref)
     (export "foo" (table 0))
     (elem (;0;) (i32.const 1) func 0)
-    (elem (;1;) (i32.const 2) func 0))
+    (elem (;1;) (i32.const 2) func 0)
+  )
 ;)

--- a/crates/tests/tests/round_trip/elem-segments-3.wat
+++ b/crates/tests/tests/round_trip/elem-segments-3.wat
@@ -13,5 +13,6 @@
     (table (;0;) 1 funcref)
     (export "foo" (table 0))
     (elem (;0;) (i32.const 1) func 0)
-    (elem (;1;) (i32.const 3) func 0))
+    (elem (;1;) (i32.const 3) func 0)
+  )
 ;)

--- a/crates/tests/tests/round_trip/entry-block-type.wat
+++ b/crates/tests/tests/round_trip/entry-block-type.wat
@@ -11,6 +11,8 @@
     (type (;0;) (func (param i64 i64) (result i64 i64)))
     (func (;0;) (type 0) (param i64 i64) (result i64 i64)
       local.get 1
-      local.get 0)
-    (export "multiLoop" (func 0)))
+      local.get 0
+    )
+    (export "multiLoop" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/fac-multi-value.wat
+++ b/crates/tests/tests/round_trip/fac-multi-value.wat
@@ -40,13 +40,17 @@
         br_if 0 (;@1;)
         drop
         return
-      end)
-    (func $pick1 (type 3) (param i64 i64) (result i64 i64 i64)
+      end
+    )
+    (func $pick1 (;1;) (type 3) (param i64 i64) (result i64 i64 i64)
       local.get 0
       local.get 1
-      local.get 0)
-    (func $pick0 (type 1) (param i64) (result i64 i64)
       local.get 0
-      local.get 0)
-    (export "fac-ssa" (func 0)))
+    )
+    (func $pick0 (;2;) (type 1) (param i64) (result i64 i64)
+      local.get 0
+      local.get 0
+    )
+    (export "fac-ssa" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/fac-multi-value.wat
+++ b/crates/tests/tests/round_trip/fac-multi-value.wat
@@ -27,7 +27,7 @@
     (func (;0;) (type 0) (param i64) (result i64)
       i64.const 1
       local.get 0
-      loop (param i64 i64) (result i64)  ;; label = @1
+      loop (type 2) (param i64 i64) (result i64) ;; label = @1
         call $pick1
         call $pick1
         i64.mul

--- a/crates/tests/tests/round_trip/fac.wat
+++ b/crates/tests/tests/round_trip/fac.wat
@@ -28,26 +28,30 @@
     local.get 1)
   (export "fac" (func $fac)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func $fac (type 0) (param i32) (result i32)
-;; NEXT:      (local i32)
-;; NEXT:      block  ;; label = @1
-;; NEXT:        local.get 0
-;; NEXT:        local.set 1
-;; NEXT:        loop  ;; label = @2
-;; NEXT:          local.get 0
-;; NEXT:          i32.eqz
-;; NEXT:          br_if 1 (;@1;)
-;; NEXT:          local.get 1
-;; NEXT:          local.get 0
-;; NEXT:          i32.mul
-;; NEXT:          local.set 1
-;; NEXT:          local.get 0
-;; NEXT:          i32.const 1
-;; NEXT:          i32.sub
-;; NEXT:          local.set 0
-;; NEXT:        end
-;; NEXT:      end
-;; NEXT:      local.get 1)
-;; NEXT:    (export "fac" (func $fac)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (param i32) (result i32)))
+    (func $fac (;0;) (type 0) (param i32) (result i32)
+      (local i32)
+      block  ;; label = @1
+        local.get 0
+        local.set 1
+        loop  ;; label = @2
+          local.get 0
+          i32.eqz
+          br_if 1 (;@1;)
+          local.get 1
+          local.get 0
+          i32.mul
+          local.set 1
+          local.get 0
+          i32.const 1
+          i32.sub
+          local.set 0
+        end
+      end
+      local.get 1
+    )
+    (export "fac" (func $fac))
+  )
+;)

--- a/crates/tests/tests/round_trip/fac.wat
+++ b/crates/tests/tests/round_trip/fac.wat
@@ -33,10 +33,10 @@
     (type (;0;) (func (param i32) (result i32)))
     (func $fac (;0;) (type 0) (param i32) (result i32)
       (local i32)
-      block  ;; label = @1
+      block ;; label = @1
         local.get 0
         local.set 1
-        loop  ;; label = @2
+        loop ;; label = @2
           local.get 0
           i32.eqz
           br_if 1 (;@1;)

--- a/crates/tests/tests/round_trip/fuzz-0.wat
+++ b/crates/tests/tests/round_trip/fuzz-0.wat
@@ -8,9 +8,11 @@
 (; CHECK-ALL:
   (module
     (type (;0;) (func))
-    (func $b (type 0)
-      data.drop 0)
+    (func $b (;0;) (type 0)
+      data.drop 0
+    )
     (memory (;0;) 1)
     (export "" (func $b))
-    (data (;0;) (i32.const 0) ""))
+    (data (;0;) (i32.const 0) "")
+  )
 ;)

--- a/crates/tests/tests/round_trip/gc_keep_used_funcs.wat
+++ b/crates/tests/tests/round_trip/gc_keep_used_funcs.wat
@@ -8,13 +8,17 @@
     (call $f))
   (export "g" (func $g)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      i32.const 42
-;; NEXT:      i32.const 1
-;; NEXT:      i32.add)
-;; NEXT:    (func $g (type 0) (result i32)
-;; NEXT:      call $f)
-;; NEXT:    (export "g" (func $g)))
-
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 42
+      i32.const 1
+      i32.add
+    )
+    (func $g (;1;) (type 0) (result i32)
+      call $f
+    )
+    (export "g" (func $g))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_keep_used_globals.wat
+++ b/crates/tests/tests/round_trip/gc_keep_used_globals.wat
@@ -4,7 +4,9 @@
   (global $used i32 (i32.const 666))
   (export "g" (global $used)))
 
-;; CHECK: (module
-;; NEXT:    (global (;0;) i32 (i32.const 666))
-;; NEXT:    (export "g" (global 0)))
-
+(; CHECK-ALL:
+  (module
+    (global (;0;) i32 i32.const 666)
+    (export "g" (global 0))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_keep_used_imports.wat
+++ b/crates/tests/tests/round_trip/gc_keep_used_imports.wat
@@ -5,7 +5,10 @@
   (import "env" "used" (func $used (type 0)))
   (export "used" (func $used)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (import "env" "used" (func $used (type 0)))
-;; NEXT:    (export "used" (func $used)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (import "env" "used" (func $used (;0;) (type 0)))
+    (export "used" (func $used))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_keep_used_memories.wat
+++ b/crates/tests/tests/round_trip/gc_keep_used_memories.wat
@@ -4,6 +4,9 @@
   (memory $m 2)
   (export "m" (memory $m)))
 
-;; CHECK: (module
-;; NEXT:    (memory (;0;) 2)
-;; NEXT:    (export "m" (memory 0)))
+(; CHECK-ALL:
+  (module
+    (memory (;0;) 2)
+    (export "m" (memory 0))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_keep_used_tables.wat
+++ b/crates/tests/tests/round_trip/gc_keep_used_tables.wat
@@ -5,6 +5,9 @@
   (table 1 1 anyfunc)
   (export "t" (table 0)))
 
-;; CHECK:  (module
-;; NEXT:    (table (;0;) 1 1 funcref)
-;; NEXT:    (export "t" (table 0)))
+(; CHECK-ALL:
+  (module
+    (table (;0;) 1 1 funcref)
+    (export "t" (table 0))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_unused_block.wat
+++ b/crates/tests/tests/round_trip/gc_unused_block.wat
@@ -14,10 +14,12 @@
 (; CHECK-ALL:
   (module
     (type (;0;) (func (result i32)))
-    (func $f (type 0) (result i32)
+    (func $f (;0;) (type 0) (result i32)
       block  ;; label = @1
         br 0 (;@1;)
       end
-      i32.const 42)
-    (export "f" (func $f)))
+      i32.const 42
+    )
+    (export "f" (func $f))
+  )
 ;)

--- a/crates/tests/tests/round_trip/gc_unused_block.wat
+++ b/crates/tests/tests/round_trip/gc_unused_block.wat
@@ -15,7 +15,7 @@
   (module
     (type (;0;) (func (result i32)))
     (func $f (;0;) (type 0) (result i32)
-      block  ;; label = @1
+      block ;; label = @1
         br 0 (;@1;)
       end
       i32.const 42

--- a/crates/tests/tests/round_trip/gc_unused_funcs.wat
+++ b/crates/tests/tests/round_trip/gc_unused_funcs.wat
@@ -8,8 +8,12 @@
     i32.const 42)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 42
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_unused_funcs_2.wat
+++ b/crates/tests/tests/round_trip/gc_unused_funcs_2.wat
@@ -14,8 +14,12 @@
     i32.const 42)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 42
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_unused_global.wat
+++ b/crates/tests/tests/round_trip/gc_unused_global.wat
@@ -7,8 +7,12 @@
     i32.const 42)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 42
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_unused_imports.wat
+++ b/crates/tests/tests/round_trip/gc_unused_imports.wat
@@ -7,8 +7,12 @@
     i32.const 42)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 42
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_unused_memories.wat
+++ b/crates/tests/tests/round_trip/gc_unused_memories.wat
@@ -7,8 +7,12 @@
     i32.const 42)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 42
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_unused_tables.wat
+++ b/crates/tests/tests/round_trip/gc_unused_tables.wat
@@ -7,8 +7,12 @@
     i32.const 42)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 42
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/gc_unused_types.wat
+++ b/crates/tests/tests/round_trip/gc_unused_types.wat
@@ -7,8 +7,12 @@
     i32.const 42)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 42
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/global-init.wat
+++ b/crates/tests/tests/round_trip/global-init.wat
@@ -3,8 +3,10 @@
   (global i32 (global.get 0))
   (export "x" (global 1)))
 
-;; CHECK: (module
-;; NEXT:    (import "x" "y" (global (;0;) i32))
-;; NEXT:    (global (;1;) i32 (global.get 0))
-;; NEXT:    (export "x" (global 1)))
-
+(; CHECK-ALL:
+  (module
+    (import "x" "y" (global (;0;) i32))
+    (global (;1;) i32 global.get 0)
+    (export "x" (global 1))
+  )
+;)

--- a/crates/tests/tests/round_trip/globals.wat
+++ b/crates/tests/tests/round_trip/globals.wat
@@ -2,4 +2,9 @@
   (global (mut i32) (i32.const 0))
   (export "a" (global 0)))
 
-;; CHECK: (global (;0;) (mut i32) (i32.const 0))
+(; CHECK-ALL:
+  (module
+    (global (;0;) (mut i32) i32.const 0)
+    (export "a" (global 0))
+  )
+;)

--- a/crates/tests/tests/round_trip/if_else.wat
+++ b/crates/tests/tests/round_trip/if_else.wat
@@ -9,13 +9,17 @@
     end)
   (export "if_else" (func $if_else)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func $if_else (type 0) (param i32) (result i32)
-;; NEXT:      local.get 0
-;; NEXT:      if (result i32)  ;; label = @1
-;; NEXT:        i32.const 1
-;; NEXT:      else
-;; NEXT:        i32.const 2
-;; NEXT:      end)
-;; NEXT:    (export "if_else" (func $if_else)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (param i32) (result i32)))
+    (func $if_else (;0;) (type 0) (param i32) (result i32)
+      local.get 0
+      if (result i32)  ;; label = @1
+        i32.const 1
+      else
+        i32.const 2
+      end
+    )
+    (export "if_else" (func $if_else))
+  )
+;)

--- a/crates/tests/tests/round_trip/if_else.wat
+++ b/crates/tests/tests/round_trip/if_else.wat
@@ -14,7 +14,7 @@
     (type (;0;) (func (param i32) (result i32)))
     (func $if_else (;0;) (type 0) (param i32) (result i32)
       local.get 0
-      if (result i32)  ;; label = @1
+      if (result i32) ;; label = @1
         i32.const 1
       else
         i32.const 2

--- a/crates/tests/tests/round_trip/if_else_2.wat
+++ b/crates/tests/tests/round_trip/if_else_2.wat
@@ -13,17 +13,21 @@
     end)
   (export "if_else" (func $if_else)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func $if_else (type 0) (param i32) (result i32)
-;; NEXT:      local.get 0
-;; NEXT:      if (result i32)  ;; label = @1
-;; NEXT:        i32.const 2
-;; NEXT:        local.set 0
-;; NEXT:        i32.const 1
-;; NEXT:      else
-;; NEXT:        i32.const 1
-;; NEXT:        local.set 0
-;; NEXT:        i32.const 2
-;; NEXT:      end)
-;; NEXT:    (export "if_else" (func $if_else)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (param i32) (result i32)))
+    (func $if_else (;0;) (type 0) (param i32) (result i32)
+      local.get 0
+      if (result i32)  ;; label = @1
+        i32.const 2
+        local.set 0
+        i32.const 1
+      else
+        i32.const 1
+        local.set 0
+        i32.const 2
+      end
+    )
+    (export "if_else" (func $if_else))
+  )
+;)

--- a/crates/tests/tests/round_trip/if_else_2.wat
+++ b/crates/tests/tests/round_trip/if_else_2.wat
@@ -18,7 +18,7 @@
     (type (;0;) (func (param i32) (result i32)))
     (func $if_else (;0;) (type 0) (param i32) (result i32)
       local.get 0
-      if (result i32)  ;; label = @1
+      if (result i32) ;; label = @1
         i32.const 2
         local.set 0
         i32.const 1

--- a/crates/tests/tests/round_trip/import-func.wat
+++ b/crates/tests/tests/round_trip/import-func.wat
@@ -4,7 +4,10 @@
   (export "b" (func 0))
   )
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func))
-;; NEXT:    (import "" "" (func (;0;) (type 0)))
-;; NEXT:    (export "b" (func 0)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (import "" "" (func (;0;) (type 0)))
+    (export "b" (func 0))
+  )
+;)

--- a/crates/tests/tests/round_trip/import-global.wat
+++ b/crates/tests/tests/round_trip/import-global.wat
@@ -3,6 +3,9 @@
   (export "b" (global 0))
   )
 
-;; CHECK: (module
-;; NEXT:    (import "" "" (global (;0;) i32))
-;; NEXT:    (export "b" (global 0)))
+(; CHECK-ALL:
+  (module
+    (import "" "" (global (;0;) i32))
+    (export "b" (global 0))
+  )
+;)

--- a/crates/tests/tests/round_trip/import-memory.wat
+++ b/crates/tests/tests/round_trip/import-memory.wat
@@ -3,7 +3,9 @@
   (export "b" (memory 0))
   )
 
-;; CHECK: (module
-;; NEXT:    (import "" "" (memory (;0;) 1))
-;; NEXT:    (export "b" (memory 0)))
-
+(; CHECK-ALL:
+  (module
+    (import "" "" (memory (;0;) 1))
+    (export "b" (memory 0))
+  )
+;)

--- a/crates/tests/tests/round_trip/import-table.wat
+++ b/crates/tests/tests/round_trip/import-table.wat
@@ -3,6 +3,9 @@
   (export "b" (table 0))
   )
 
-;; CHECK: (module
-;; NEXT:    (import "" "" (table (;0;) 1 funcref))
-;; NEXT:    (export "b" (table 0)))
+(; CHECK-ALL:
+  (module
+    (import "" "" (table (;0;) 1 funcref))
+    (export "b" (table 0))
+  )
+;)

--- a/crates/tests/tests/round_trip/inc.wat
+++ b/crates/tests/tests/round_trip/inc.wat
@@ -6,10 +6,14 @@
       (i32.const 1)))
   (export "inc" (func $inc)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func $inc (type 0) (param i32) (result i32)
-;; NEXT:      local.get 0
-;; NEXT:      i32.const 1
-;; NEXT:      i32.add)
-;; NEXT:    (export "inc" (func $inc)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (param i32) (result i32)))
+    (func $inc (;0;) (type 0) (param i32) (result i32)
+      local.get 0
+      i32.const 1
+      i32.add
+    )
+    (export "inc" (func $inc))
+  )
+;)

--- a/crates/tests/tests/round_trip/keep-elem-segments.wat
+++ b/crates/tests/tests/round_trip/keep-elem-segments.wat
@@ -18,9 +18,11 @@
     (type (;0;) (func))
     (func (;0;) (type 0)
       i32.const 0
-      call_indirect (type 0))
+      call_indirect (type 0)
+    )
     (func (;1;) (type 0))
     (table (;0;) 1 1 funcref)
     (export "foo" (func 0))
-    (elem (;0;) (i32.const 0) func 1))
+    (elem (;0;) (i32.const 0) func 1)
+  )
 ;)

--- a/crates/tests/tests/round_trip/local-get.wat
+++ b/crates/tests/tests/round_trip/local-get.wat
@@ -8,7 +8,7 @@
   (module
     (type (;0;) (func (param i32) (result i32)))
     (func (;0;) (type 0) (param i32) (result i32)
-      block (result i32)  ;; label = @1
+      block (result i32) ;; label = @1
         local.get 0
         br 0 (;@1;)
       end

--- a/crates/tests/tests/round_trip/local-get.wat
+++ b/crates/tests/tests/round_trip/local-get.wat
@@ -11,6 +11,8 @@
       block (result i32)  ;; label = @1
         local.get 0
         br 0 (;@1;)
-      end)
-    (export "as-br-value" (func 0)))
+      end
+    )
+    (export "as-br-value" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/loop.wat
+++ b/crates/tests/tests/round_trip/loop.wat
@@ -5,9 +5,13 @@
     end)
   (export "inf_loop" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func))
-;; NEXT:    (func $f (type 0)
-;; NEXT:      loop  ;; label = @1
-;; NEXT:      end)
-;; NEXT:    (export "inf_loop" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func $f (;0;) (type 0)
+      loop  ;; label = @1
+      end
+    )
+    (export "inf_loop" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/loop.wat
+++ b/crates/tests/tests/round_trip/loop.wat
@@ -9,7 +9,7 @@
   (module
     (type (;0;) (func))
     (func $f (;0;) (type 0)
-      loop  ;; label = @1
+      loop ;; label = @1
       end
     )
     (export "inf_loop" (func $f))

--- a/crates/tests/tests/round_trip/loop2.wat
+++ b/crates/tests/tests/round_trip/loop2.wat
@@ -6,14 +6,18 @@
       (br_if 1 (local.get 0)))
   ))
 
-;; CHECK:    (module
-;; NEXT:       (type (;0;) (func))
-;; NEXT:       (type (;1;) (func (param i32)))
-;; NEXT:       (func (;0;) (type 1) (param i32)
-;; NEXT:         loop  ;; label = @1
-;; NEXT:           call $dummy
-;; NEXT:           local.get 0
-;; NEXT:           br_if 1 (;@0;)
-;; NEXT:         end)
-;; NEXT:       (func $dummy (type 0))
-;; NEXT:       (export "as-loop-last" (func 0)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (type (;1;) (func (param i32)))
+    (func (;0;) (type 1) (param i32)
+      loop  ;; label = @1
+        call $dummy
+        local.get 0
+        br_if 1 (;@0;)
+      end
+    )
+    (func $dummy (;1;) (type 0))
+    (export "as-loop-last" (func 0))
+  )
+;)

--- a/crates/tests/tests/round_trip/loop2.wat
+++ b/crates/tests/tests/round_trip/loop2.wat
@@ -11,7 +11,7 @@
     (type (;0;) (func))
     (type (;1;) (func (param i32)))
     (func (;0;) (type 1) (param i32)
-      loop  ;; label = @1
+      loop ;; label = @1
         call $dummy
         local.get 0
         br_if 1 (;@0;)

--- a/crates/tests/tests/round_trip/many_funcs.wat
+++ b/crates/tests/tests/round_trip/many_funcs.wat
@@ -19,30 +19,36 @@
 
 ;; Note that these functions get properly sorted from largest to smallest.
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $d (type 0) (result i32)
-;; NEXT:      i32.const 0
-;; NEXT:      i32.const 1
-;; NEXT:      i32.add
-;; NEXT:      i32.const 2
-;; NEXT:      i32.const 3
-;; NEXT:      i32.add
-;; NEXT:      i32.add)
-;; NEXT:    (func $c (type 0) (result i32)
-;; NEXT:      i32.const 3
-;; NEXT:      i32.const 4
-;; NEXT:      i32.const 5
-;; NEXT:      i32.add
-;; NEXT:      i32.add)
-;; NEXT:    (func $b (type 0) (result i32)
-;; NEXT:      i32.const 1
-;; NEXT:      i32.const 2
-;; NEXT:      i32.add)
-;; NEXT:    (func $a (type 0) (result i32)
-;; NEXT:      i32.const 0)
-;; NEXT:    (export "a" (func $a))
-;; NEXT:    (export "b" (func $b))
-;; NEXT:    (export "c" (func $c))
-;; NEXT:    (export "d" (func $d)))
-
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $d (;0;) (type 0) (result i32)
+      i32.const 0
+      i32.const 1
+      i32.add
+      i32.const 2
+      i32.const 3
+      i32.add
+      i32.add
+    )
+    (func $c (;1;) (type 0) (result i32)
+      i32.const 3
+      i32.const 4
+      i32.const 5
+      i32.add
+      i32.add
+    )
+    (func $b (;2;) (type 0) (result i32)
+      i32.const 1
+      i32.const 2
+      i32.add
+    )
+    (func $a (;3;) (type 0) (result i32)
+      i32.const 0
+    )
+    (export "a" (func $a))
+    (export "b" (func $b))
+    (export "c" (func $c))
+    (export "d" (func $d))
+  )
+;)

--- a/crates/tests/tests/round_trip/mem.wat
+++ b/crates/tests/tests/round_trip/mem.wat
@@ -18,7 +18,9 @@
       drop
       i32.const 2
       f32.const 0x1.8p+1 (;=3;)
-      f32.store)
+      f32.store
+    )
     (memory (;0;) 0)
-    (export "f" (func 0)))
+    (export "f" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/memory-init.wast
+++ b/crates/tests/tests/round_trip/memory-init.wast
@@ -5,9 +5,11 @@
   (data (global.get 0) "")
   (export "x" (memory 0)))
 
-;; CHECK: (module
-;; NEXT:    (import "x" "y" (global (;0;) i32))
-;; NEXT:    (memory (;0;) 1)
-;; NEXT:    (export "x" (memory 0))
-;; NEXT:    (data (;0;) (global.get 0) ""))
-
+(; CHECK-ALL:
+  (module
+    (import "x" "y" (global (;0;) i32))
+    (memory (;0;) 1)
+    (export "x" (memory 0))
+    (data (;0;) (global.get 0) "")
+  )
+;)

--- a/crates/tests/tests/round_trip/memory-size.wat
+++ b/crates/tests/tests/round_trip/memory-size.wat
@@ -8,7 +8,9 @@
   (module
     (type (;0;) (func (result i32)))
     (func (;0;) (type 0) (result i32)
-      memory.size)
+      memory.size
+    )
     (memory (;0;) 0)
-    (export "get" (func 0)))
+    (export "get" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/multi-0.wat
+++ b/crates/tests/tests/round_trip/multi-0.wat
@@ -7,6 +7,8 @@
     (type (;0;) (func (param i64) (result i64 i64)))
     (func (;0;) (type 0) (param i64) (result i64 i64)
       local.get 0
-      local.get 0)
-    (export "i64.dup" (func 0)))
+      local.get 0
+    )
+    (export "i64.dup" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/multi-1.wat
+++ b/crates/tests/tests/round_trip/multi-1.wat
@@ -13,6 +13,8 @@
       local.get 0
       block (param i64 i64) (result i64 i64 i64)  ;; label = @1
         i64.const 1234
-      end)
-    (export "multiBlock" (func 0)))
+      end
+    )
+    (export "multiBlock" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/multi-1.wat
+++ b/crates/tests/tests/round_trip/multi-1.wat
@@ -11,7 +11,7 @@
     (func (;0;) (type 0) (param i64 i64) (result i64 i64 i64)
       local.get 1
       local.get 0
-      block (param i64 i64) (result i64 i64 i64)  ;; label = @1
+      block (type 0) (param i64 i64) (result i64 i64 i64) ;; label = @1
         i64.const 1234
       end
     )

--- a/crates/tests/tests/round_trip/multi-2.wat
+++ b/crates/tests/tests/round_trip/multi-2.wat
@@ -13,6 +13,8 @@
       local.get 0
       loop (param i64 i64) (result i64 i64)  ;; label = @1
         return
-      end)
-    (export "multiLoop" (func 0)))
+      end
+    )
+    (export "multiLoop" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/multi-2.wat
+++ b/crates/tests/tests/round_trip/multi-2.wat
@@ -11,7 +11,7 @@
     (func (;0;) (type 0) (param i64 i64) (result i64 i64)
       local.get 1
       local.get 0
-      loop (param i64 i64) (result i64 i64)  ;; label = @1
+      loop (type 0) (param i64 i64) (result i64 i64) ;; label = @1
         return
       end
     )

--- a/crates/tests/tests/round_trip/multi-3.wat
+++ b/crates/tests/tests/round_trip/multi-3.wat
@@ -26,6 +26,8 @@
         drop
         i64.const 0
         i64.const 0
-      end)
-    (export "multiLoop" (func 0)))
+      end
+    )
+    (export "multiLoop" (func 0))
+  )
 ;)

--- a/crates/tests/tests/round_trip/multi-3.wat
+++ b/crates/tests/tests/round_trip/multi-3.wat
@@ -19,7 +19,7 @@
       local.get 2
       local.get 1
       local.get 0
-      if (param i64 i64) (result i64 i64)  ;; label = @1
+      if (type 1) (param i64 i64) (result i64 i64) ;; label = @1
         return
       else
         drop

--- a/crates/tests/tests/round_trip/not-tree-like.wat
+++ b/crates/tests/tests/round_trip/not-tree-like.wat
@@ -13,7 +13,7 @@
   (module
     (type (;0;) (func (result i32)))
     (type (;1;) (func (param i32) (result i32)))
-    (import "env" "blackbox" (func $blackbox (type 1)))
+    (import "env" "blackbox" (func $blackbox (;0;) (type 1)))
     (func (;1;) (type 0) (result i32)
       i32.const 1
       call $blackbox
@@ -22,6 +22,8 @@
       drop
       i32.const 3
       call $blackbox
-      i32.add)
-    (export "$f" (func 1)))
+      i32.add
+    )
+    (export "$f" (func 1))
+  )
 ;)

--- a/crates/tests/tests/round_trip/params.wat
+++ b/crates/tests/tests/round_trip/params.wat
@@ -5,7 +5,14 @@
     i32.add)
   (export "foo" (func 0)))
 
-;; CHECK: (func (;0;) (type 0) (param i32 i32) (result i32)
-;; NEXT:    local.get 1
-;; NEXT:    local.get 0
-;; NEXT:    i32.add)
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (param i32 i32) (result i32)))
+    (func (;0;) (type 0) (param i32 i32) (result i32)
+      local.get 1
+      local.get 0
+      i32.add
+    )
+    (export "foo" (func 0))
+  )
+;)

--- a/crates/tests/tests/round_trip/return.wat
+++ b/crates/tests/tests/round_trip/return.wat
@@ -3,6 +3,13 @@
     (return (i32.const 1)))
   (export "f" (func $f)))
 
-;; CHECK: (func $f (type 0) (result i32)
-;; NEXT:    i32.const 1
-;; NEXT:    return)
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 1
+      return
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/return_2.wat
+++ b/crates/tests/tests/round_trip/return_2.wat
@@ -4,6 +4,13 @@
     i32.const 2)
   (export "f" (func $f)))
 
-;; CHECK: (func $f (type 0) (result i32)
-;; NEXT:    i32.const 1
-;; NEXT:    return)
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      i32.const 1
+      return
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/select.wat
+++ b/crates/tests/tests/round_trip/select.wat
@@ -7,11 +7,15 @@
     select)
   (export "do_select" (func $do_select)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (param i32) (result i32)))
-;; NEXT:    (func $do_select (type 0) (param i32) (result i32)
-;; NEXT:      i32.const 2
-;; NEXT:      i32.const 1
-;; NEXT:      local.get 0
-;; NEXT:      select)
-;; NEXT:    (export "do_select" (func $do_select)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (param i32) (result i32)))
+    (func $do_select (;0;) (type 0) (param i32) (result i32)
+      i32.const 2
+      i32.const 1
+      local.get 0
+      select
+    )
+    (export "do_select" (func $do_select))
+  )
+;)

--- a/crates/tests/tests/round_trip/simd.wat
+++ b/crates/tests/tests/round_trip/simd.wat
@@ -514,471 +514,596 @@
     (type (;14;) (func (param v128 f64) (result v128)))
     (type (;15;) (func (param v128 v128) (result v128)))
     (type (;16;) (func (param v128 v128 v128) (result v128)))
-    (func $v128.bitselect (type 16) (param v128 v128 v128) (result v128)
+    (func $v128.bitselect (;0;) (type 16) (param v128 v128 v128) (result v128)
       local.get 0
       local.get 1
       local.get 2
-      v128.bitselect)
-    (func $v128.store (type 2) (param i32 v128)
+      v128.bitselect
+    )
+    (func $v128.store (;1;) (type 2) (param i32 v128)
       local.get 0
       local.get 1
-      v128.store)
-    (func $i8x16.replace_lane (type 11) (param v128 i32) (result v128)
+      v128.store
+    )
+    (func $i8x16.replace_lane (;2;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i8x16.replace_lane 2)
-    (func $i16x8.replace_lane (type 11) (param v128 i32) (result v128)
+      i8x16.replace_lane 2
+    )
+    (func $i16x8.replace_lane (;3;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i16x8.replace_lane 2)
-    (func $i32x4.replace_lane (type 11) (param v128 i32) (result v128)
+      i16x8.replace_lane 2
+    )
+    (func $i32x4.replace_lane (;4;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i32x4.replace_lane 2)
-    (func $i64x2.replace_lane (type 12) (param v128 i64) (result v128)
+      i32x4.replace_lane 2
+    )
+    (func $i64x2.replace_lane (;5;) (type 12) (param v128 i64) (result v128)
       local.get 0
       local.get 1
-      i64x2.replace_lane 0)
-    (func $f32x4.replace_lane (type 13) (param v128 f32) (result v128)
+      i64x2.replace_lane 0
+    )
+    (func $f32x4.replace_lane (;6;) (type 13) (param v128 f32) (result v128)
       local.get 0
       local.get 1
-      f32x4.replace_lane 2)
-    (func $f64x2.replace_lane (type 14) (param v128 f64) (result v128)
+      f32x4.replace_lane 2
+    )
+    (func $f64x2.replace_lane (;7;) (type 14) (param v128 f64) (result v128)
       local.get 0
       local.get 1
-      f64x2.replace_lane 0)
-    (func $i8x16.eq (type 15) (param v128 v128) (result v128)
+      f64x2.replace_lane 0
+    )
+    (func $i8x16.eq (;8;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.eq)
-    (func $i8x16.lt_s (type 15) (param v128 v128) (result v128)
+      i8x16.eq
+    )
+    (func $i8x16.lt_s (;9;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.lt_s)
-    (func $i8x16.lt_u (type 15) (param v128 v128) (result v128)
+      i8x16.lt_s
+    )
+    (func $i8x16.lt_u (;10;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.lt_u)
-    (func $i8x16.gt_s (type 15) (param v128 v128) (result v128)
+      i8x16.lt_u
+    )
+    (func $i8x16.gt_s (;11;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.gt_s)
-    (func $i8x16.gt_u (type 15) (param v128 v128) (result v128)
+      i8x16.gt_s
+    )
+    (func $i8x16.gt_u (;12;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.gt_u)
-    (func $i8x16.le_s (type 15) (param v128 v128) (result v128)
+      i8x16.gt_u
+    )
+    (func $i8x16.le_s (;13;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.le_s)
-    (func $i8x16.le_u (type 15) (param v128 v128) (result v128)
+      i8x16.le_s
+    )
+    (func $i8x16.le_u (;14;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.le_u)
-    (func $i8x16.ge_s (type 15) (param v128 v128) (result v128)
+      i8x16.le_u
+    )
+    (func $i8x16.ge_s (;15;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.ge_s)
-    (func $i8x16.ge_u (type 15) (param v128 v128) (result v128)
+      i8x16.ge_s
+    )
+    (func $i8x16.ge_u (;16;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.ge_u)
-    (func $i16x8.eq (type 15) (param v128 v128) (result v128)
+      i8x16.ge_u
+    )
+    (func $i16x8.eq (;17;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.eq)
-    (func $i16x8.lt_s (type 15) (param v128 v128) (result v128)
+      i16x8.eq
+    )
+    (func $i16x8.lt_s (;18;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.lt_s)
-    (func $i16x8.lt_u (type 15) (param v128 v128) (result v128)
+      i16x8.lt_s
+    )
+    (func $i16x8.lt_u (;19;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.lt_u)
-    (func $i16x8.gt_s (type 15) (param v128 v128) (result v128)
+      i16x8.lt_u
+    )
+    (func $i16x8.gt_s (;20;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.gt_s)
-    (func $i16x8.gt_u (type 15) (param v128 v128) (result v128)
+      i16x8.gt_s
+    )
+    (func $i16x8.gt_u (;21;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.gt_u)
-    (func $i16x8.le_s (type 15) (param v128 v128) (result v128)
+      i16x8.gt_u
+    )
+    (func $i16x8.le_s (;22;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.le_s)
-    (func $i16x8.le_u (type 15) (param v128 v128) (result v128)
+      i16x8.le_s
+    )
+    (func $i16x8.le_u (;23;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.le_u)
-    (func $i16x8.ge_s (type 15) (param v128 v128) (result v128)
+      i16x8.le_u
+    )
+    (func $i16x8.ge_s (;24;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.ge_s)
-    (func $i16x8.ge_u (type 15) (param v128 v128) (result v128)
+      i16x8.ge_s
+    )
+    (func $i16x8.ge_u (;25;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.ge_u)
-    (func $i32x4.eq (type 15) (param v128 v128) (result v128)
+      i16x8.ge_u
+    )
+    (func $i32x4.eq (;26;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.eq)
-    (func $i32x4.lt_s (type 15) (param v128 v128) (result v128)
+      i32x4.eq
+    )
+    (func $i32x4.lt_s (;27;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.lt_s)
-    (func $i32x4.lt_u (type 15) (param v128 v128) (result v128)
+      i32x4.lt_s
+    )
+    (func $i32x4.lt_u (;28;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.lt_u)
-    (func $i32x4.gt_s (type 15) (param v128 v128) (result v128)
+      i32x4.lt_u
+    )
+    (func $i32x4.gt_s (;29;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.gt_s)
-    (func $i32x4.gt_u (type 15) (param v128 v128) (result v128)
+      i32x4.gt_s
+    )
+    (func $i32x4.gt_u (;30;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.gt_u)
-    (func $i32x4.le_s (type 15) (param v128 v128) (result v128)
+      i32x4.gt_u
+    )
+    (func $i32x4.le_s (;31;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.le_s)
-    (func $i32x4.le_u (type 15) (param v128 v128) (result v128)
+      i32x4.le_s
+    )
+    (func $i32x4.le_u (;32;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.le_u)
-    (func $i32x4.ge_s (type 15) (param v128 v128) (result v128)
+      i32x4.le_u
+    )
+    (func $i32x4.ge_s (;33;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.ge_s)
-    (func $i32x4.ge_u (type 15) (param v128 v128) (result v128)
+      i32x4.ge_s
+    )
+    (func $i32x4.ge_u (;34;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.ge_u)
-    (func $f32x4.eq (type 15) (param v128 v128) (result v128)
+      i32x4.ge_u
+    )
+    (func $f32x4.eq (;35;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.eq)
-    (func $f32x4.lt (type 15) (param v128 v128) (result v128)
+      f32x4.eq
+    )
+    (func $f32x4.lt (;36;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.lt)
-    (func $f32x4.gt (type 15) (param v128 v128) (result v128)
+      f32x4.lt
+    )
+    (func $f32x4.gt (;37;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.gt)
-    (func $f32x4.le (type 15) (param v128 v128) (result v128)
+      f32x4.gt
+    )
+    (func $f32x4.le (;38;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.le)
-    (func $f32x4.ge (type 15) (param v128 v128) (result v128)
+      f32x4.le
+    )
+    (func $f32x4.ge (;39;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.ge)
-    (func $f64x2.eq (type 15) (param v128 v128) (result v128)
+      f32x4.ge
+    )
+    (func $f64x2.eq (;40;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.eq)
-    (func $f64x2.lt (type 15) (param v128 v128) (result v128)
+      f64x2.eq
+    )
+    (func $f64x2.lt (;41;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.lt)
-    (func $f64x2.gt (type 15) (param v128 v128) (result v128)
+      f64x2.lt
+    )
+    (func $f64x2.gt (;42;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.gt)
-    (func $f64x2.le (type 15) (param v128 v128) (result v128)
+      f64x2.gt
+    )
+    (func $f64x2.le (;43;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.le)
-    (func $f64x2.ge (type 15) (param v128 v128) (result v128)
+      f64x2.le
+    )
+    (func $f64x2.ge (;44;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.ge)
-    (func $v128.and (type 15) (param v128 v128) (result v128)
+      f64x2.ge
+    )
+    (func $v128.and (;45;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      v128.and)
-    (func $v128.or (type 15) (param v128 v128) (result v128)
+      v128.and
+    )
+    (func $v128.or (;46;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      v128.or)
-    (func $v128.xor (type 15) (param v128 v128) (result v128)
+      v128.or
+    )
+    (func $v128.xor (;47;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      v128.xor)
-    (func $i8x16.shl (type 11) (param v128 i32) (result v128)
+      v128.xor
+    )
+    (func $i8x16.shl (;48;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i8x16.shl)
-    (func $i8x16.shr_s (type 11) (param v128 i32) (result v128)
+      i8x16.shl
+    )
+    (func $i8x16.shr_s (;49;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i8x16.shr_s)
-    (func $i8x16.shr_u (type 11) (param v128 i32) (result v128)
+      i8x16.shr_s
+    )
+    (func $i8x16.shr_u (;50;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i8x16.shr_u)
-    (func $i8x16.add (type 15) (param v128 v128) (result v128)
+      i8x16.shr_u
+    )
+    (func $i8x16.add (;51;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.add)
-    (func $i8x16.add_sat_u (type 15) (param v128 v128) (result v128)
+      i8x16.add
+    )
+    (func $i8x16.add_sat_u (;52;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.add_sat_u)
-    (func $i8x16.add_sat_s (type 15) (param v128 v128) (result v128)
+      i8x16.add_sat_u
+    )
+    (func $i8x16.add_sat_s (;53;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.add_sat_s)
-    (func $i8x16.sub (type 15) (param v128 v128) (result v128)
+      i8x16.add_sat_s
+    )
+    (func $i8x16.sub (;54;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.sub)
-    (func $i8x16.sub_sat_u (type 15) (param v128 v128) (result v128)
+      i8x16.sub
+    )
+    (func $i8x16.sub_sat_u (;55;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.sub_sat_u)
-    (func $i8x16.sub_sat_s (type 15) (param v128 v128) (result v128)
+      i8x16.sub_sat_u
+    )
+    (func $i8x16.sub_sat_s (;56;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i8x16.sub_sat_s)
-    (func $i16x8.shl (type 11) (param v128 i32) (result v128)
+      i8x16.sub_sat_s
+    )
+    (func $i16x8.shl (;57;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i16x8.shl)
-    (func $i16x8.shr_s (type 11) (param v128 i32) (result v128)
+      i16x8.shl
+    )
+    (func $i16x8.shr_s (;58;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i16x8.shr_s)
-    (func $i16x8.shr_u (type 11) (param v128 i32) (result v128)
+      i16x8.shr_s
+    )
+    (func $i16x8.shr_u (;59;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i16x8.shr_u)
-    (func $i16x8.add (type 15) (param v128 v128) (result v128)
+      i16x8.shr_u
+    )
+    (func $i16x8.add (;60;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.add)
-    (func $i16x8.add_sat_u (type 15) (param v128 v128) (result v128)
+      i16x8.add
+    )
+    (func $i16x8.add_sat_u (;61;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.add_sat_u)
-    (func $i16x8.add_sat_s (type 15) (param v128 v128) (result v128)
+      i16x8.add_sat_u
+    )
+    (func $i16x8.add_sat_s (;62;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.add_sat_s)
-    (func $i16x8.sub (type 15) (param v128 v128) (result v128)
+      i16x8.add_sat_s
+    )
+    (func $i16x8.sub (;63;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.sub)
-    (func $i16x8.sub_sat_u (type 15) (param v128 v128) (result v128)
+      i16x8.sub
+    )
+    (func $i16x8.sub_sat_u (;64;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.sub_sat_u)
-    (func $i16x8.sub_sat_s (type 15) (param v128 v128) (result v128)
+      i16x8.sub_sat_u
+    )
+    (func $i16x8.sub_sat_s (;65;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.sub_sat_s)
-    (func $i16x8.mul (type 15) (param v128 v128) (result v128)
+      i16x8.sub_sat_s
+    )
+    (func $i16x8.mul (;66;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i16x8.mul)
-    (func $i32x4.shl (type 11) (param v128 i32) (result v128)
+      i16x8.mul
+    )
+    (func $i32x4.shl (;67;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i32x4.shl)
-    (func $i32x4.shr_s (type 11) (param v128 i32) (result v128)
+      i32x4.shl
+    )
+    (func $i32x4.shr_s (;68;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i32x4.shr_s)
-    (func $i32x4.shr_u (type 11) (param v128 i32) (result v128)
+      i32x4.shr_s
+    )
+    (func $i32x4.shr_u (;69;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i32x4.shr_u)
-    (func $i32x4.add (type 15) (param v128 v128) (result v128)
+      i32x4.shr_u
+    )
+    (func $i32x4.add (;70;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.add)
-    (func $i32x4.sub (type 15) (param v128 v128) (result v128)
+      i32x4.add
+    )
+    (func $i32x4.sub (;71;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.sub)
-    (func $i32x4.mul (type 15) (param v128 v128) (result v128)
+      i32x4.sub
+    )
+    (func $i32x4.mul (;72;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i32x4.mul)
-    (func $i64x2.shl (type 11) (param v128 i32) (result v128)
+      i32x4.mul
+    )
+    (func $i64x2.shl (;73;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i64x2.shl)
-    (func $i64x2.shr_s (type 11) (param v128 i32) (result v128)
+      i64x2.shl
+    )
+    (func $i64x2.shr_s (;74;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i64x2.shr_s)
-    (func $i64x2.shr_u (type 11) (param v128 i32) (result v128)
+      i64x2.shr_s
+    )
+    (func $i64x2.shr_u (;75;) (type 11) (param v128 i32) (result v128)
       local.get 0
       local.get 1
-      i64x2.shr_u)
-    (func $i64x2.add (type 15) (param v128 v128) (result v128)
+      i64x2.shr_u
+    )
+    (func $i64x2.add (;76;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i64x2.add)
-    (func $i64x2.sub (type 15) (param v128 v128) (result v128)
+      i64x2.add
+    )
+    (func $i64x2.sub (;77;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      i64x2.sub)
-    (func $f32x4.add (type 15) (param v128 v128) (result v128)
+      i64x2.sub
+    )
+    (func $f32x4.add (;78;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.add)
-    (func $f32x4.sub (type 15) (param v128 v128) (result v128)
+      f32x4.add
+    )
+    (func $f32x4.sub (;79;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.sub)
-    (func $f32x4.mul (type 15) (param v128 v128) (result v128)
+      f32x4.sub
+    )
+    (func $f32x4.mul (;80;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.mul)
-    (func $f32x4.div (type 15) (param v128 v128) (result v128)
+      f32x4.mul
+    )
+    (func $f32x4.div (;81;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.div)
-    (func $f32x4.min (type 15) (param v128 v128) (result v128)
+      f32x4.div
+    )
+    (func $f32x4.min (;82;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.min)
-    (func $f32x4.max (type 15) (param v128 v128) (result v128)
+      f32x4.min
+    )
+    (func $f32x4.max (;83;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f32x4.max)
-    (func $f64x2.add (type 15) (param v128 v128) (result v128)
+      f32x4.max
+    )
+    (func $f64x2.add (;84;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.add)
-    (func $f64x2.sub (type 15) (param v128 v128) (result v128)
+      f64x2.add
+    )
+    (func $f64x2.sub (;85;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.sub)
-    (func $f64x2.mul (type 15) (param v128 v128) (result v128)
+      f64x2.sub
+    )
+    (func $f64x2.mul (;86;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.mul)
-    (func $f64x2.div (type 15) (param v128 v128) (result v128)
+      f64x2.mul
+    )
+    (func $f64x2.div (;87;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.div)
-    (func $f64x2.min (type 15) (param v128 v128) (result v128)
+      f64x2.div
+    )
+    (func $f64x2.min (;88;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.min)
-    (func $f64x2.max (type 15) (param v128 v128) (result v128)
+      f64x2.min
+    )
+    (func $f64x2.max (;89;) (type 15) (param v128 v128) (result v128)
       local.get 0
       local.get 1
-      f64x2.max)
-    (func $v128.load (type 1) (param i32) (result v128)
+      f64x2.max
+    )
+    (func $v128.load (;90;) (type 1) (param i32) (result v128)
       local.get 0
-      v128.load)
-    (func $i8x16.splat (type 1) (param i32) (result v128)
+      v128.load
+    )
+    (func $i8x16.splat (;91;) (type 1) (param i32) (result v128)
       local.get 0
-      i8x16.splat)
-    (func $i8x16.extract_lane_s (type 6) (param v128) (result i32)
+      i8x16.splat
+    )
+    (func $i8x16.extract_lane_s (;92;) (type 6) (param v128) (result i32)
       local.get 0
-      i8x16.extract_lane_s 1)
-    (func $i8x16.extract_lane_u (type 6) (param v128) (result i32)
+      i8x16.extract_lane_s 1
+    )
+    (func $i8x16.extract_lane_u (;93;) (type 6) (param v128) (result i32)
       local.get 0
-      i8x16.extract_lane_u 2)
-    (func $i16x8.splat (type 1) (param i32) (result v128)
+      i8x16.extract_lane_u 2
+    )
+    (func $i16x8.splat (;94;) (type 1) (param i32) (result v128)
       local.get 0
-      i16x8.splat)
-    (func $i16x8.extract_lane_s (type 6) (param v128) (result i32)
+      i16x8.splat
+    )
+    (func $i16x8.extract_lane_s (;95;) (type 6) (param v128) (result i32)
       local.get 0
-      i16x8.extract_lane_s 1)
-    (func $i16x8.extract_lane_u (type 6) (param v128) (result i32)
+      i16x8.extract_lane_s 1
+    )
+    (func $i16x8.extract_lane_u (;96;) (type 6) (param v128) (result i32)
       local.get 0
-      i16x8.extract_lane_u 2)
-    (func $i32x4.splat (type 1) (param i32) (result v128)
+      i16x8.extract_lane_u 2
+    )
+    (func $i32x4.splat (;97;) (type 1) (param i32) (result v128)
       local.get 0
-      i32x4.splat)
-    (func $i32x4.extract_lane (type 6) (param v128) (result i32)
+      i32x4.splat
+    )
+    (func $i32x4.extract_lane (;98;) (type 6) (param v128) (result i32)
       local.get 0
-      i32x4.extract_lane 1)
-    (func $i64x2.splat (type 3) (param i64) (result v128)
+      i32x4.extract_lane 1
+    )
+    (func $i64x2.splat (;99;) (type 3) (param i64) (result v128)
       local.get 0
-      i64x2.splat)
-    (func $i64x2.extract_lane (type 7) (param v128) (result i64)
+      i64x2.splat
+    )
+    (func $i64x2.extract_lane (;100;) (type 7) (param v128) (result i64)
       local.get 0
-      i64x2.extract_lane 1)
-    (func $f32x4.splat (type 4) (param f32) (result v128)
+      i64x2.extract_lane 1
+    )
+    (func $f32x4.splat (;101;) (type 4) (param f32) (result v128)
       local.get 0
-      f32x4.splat)
-    (func $f32x4.extract_lane (type 8) (param v128) (result f32)
+      f32x4.splat
+    )
+    (func $f32x4.extract_lane (;102;) (type 8) (param v128) (result f32)
       local.get 0
-      f32x4.extract_lane 1)
-    (func $f64x2.splat (type 5) (param f64) (result v128)
+      f32x4.extract_lane 1
+    )
+    (func $f64x2.splat (;103;) (type 5) (param f64) (result v128)
       local.get 0
-      f64x2.splat)
-    (func $f64x2.extract_lane (type 9) (param v128) (result f64)
+      f64x2.splat
+    )
+    (func $f64x2.extract_lane (;104;) (type 9) (param v128) (result f64)
       local.get 0
-      f64x2.extract_lane 1)
-    (func $v128.not (type 10) (param v128) (result v128)
+      f64x2.extract_lane 1
+    )
+    (func $v128.not (;105;) (type 10) (param v128) (result v128)
       local.get 0
-      v128.not)
-    (func $v128.any_true (type 6) (param v128) (result i32)
+      v128.not
+    )
+    (func $v128.any_true (;106;) (type 6) (param v128) (result i32)
       local.get 0
-      v128.any_true)
-    (func $i8x16.neg (type 10) (param v128) (result v128)
+      v128.any_true
+    )
+    (func $i8x16.neg (;107;) (type 10) (param v128) (result v128)
       local.get 0
-      i8x16.neg)
-    (func $i8x16.all_true (type 6) (param v128) (result i32)
+      i8x16.neg
+    )
+    (func $i8x16.all_true (;108;) (type 6) (param v128) (result i32)
       local.get 0
-      i8x16.all_true)
-    (func $i16x8.neg (type 10) (param v128) (result v128)
+      i8x16.all_true
+    )
+    (func $i16x8.neg (;109;) (type 10) (param v128) (result v128)
       local.get 0
-      i16x8.neg)
-    (func $i16x8.all_true (type 6) (param v128) (result i32)
+      i16x8.neg
+    )
+    (func $i16x8.all_true (;110;) (type 6) (param v128) (result i32)
       local.get 0
-      i16x8.all_true)
-    (func $i32x4.neg (type 10) (param v128) (result v128)
+      i16x8.all_true
+    )
+    (func $i32x4.neg (;111;) (type 10) (param v128) (result v128)
       local.get 0
-      i32x4.neg)
-    (func $i32x4.all_true (type 6) (param v128) (result i32)
+      i32x4.neg
+    )
+    (func $i32x4.all_true (;112;) (type 6) (param v128) (result i32)
       local.get 0
-      i32x4.all_true)
-    (func $i64x2.neg (type 10) (param v128) (result v128)
+      i32x4.all_true
+    )
+    (func $i64x2.neg (;113;) (type 10) (param v128) (result v128)
       local.get 0
-      i64x2.neg)
-    (func $f32x4.abs (type 10) (param v128) (result v128)
+      i64x2.neg
+    )
+    (func $f32x4.abs (;114;) (type 10) (param v128) (result v128)
       local.get 0
-      f32x4.abs)
-    (func $f32x4.neg (type 10) (param v128) (result v128)
+      f32x4.abs
+    )
+    (func $f32x4.neg (;115;) (type 10) (param v128) (result v128)
       local.get 0
-      f32x4.neg)
-    (func $f32x4.sqrt (type 10) (param v128) (result v128)
+      f32x4.neg
+    )
+    (func $f32x4.sqrt (;116;) (type 10) (param v128) (result v128)
       local.get 0
-      f32x4.sqrt)
-    (func $f64x2.abs (type 10) (param v128) (result v128)
+      f32x4.sqrt
+    )
+    (func $f64x2.abs (;117;) (type 10) (param v128) (result v128)
       local.get 0
-      f64x2.abs)
-    (func $f64x2.neg (type 10) (param v128) (result v128)
+      f64x2.abs
+    )
+    (func $f64x2.neg (;118;) (type 10) (param v128) (result v128)
       local.get 0
-      f64x2.neg)
-    (func $f64x2.sqrt (type 10) (param v128) (result v128)
+      f64x2.neg
+    )
+    (func $f64x2.sqrt (;119;) (type 10) (param v128) (result v128)
       local.get 0
-      f64x2.sqrt)
-    (func $i32x4_trunc_s_f32x4_sat (type 10) (param v128) (result v128)
+      f64x2.sqrt
+    )
+    (func $i32x4_trunc_s_f32x4_sat (;120;) (type 10) (param v128) (result v128)
       local.get 0
-      i32x4.trunc_sat_f32x4_s)
-    (func $i32x4_trunc_u_f32x4_sat (type 10) (param v128) (result v128)
+      i32x4.trunc_sat_f32x4_s
+    )
+    (func $i32x4_trunc_u_f32x4_sat (;121;) (type 10) (param v128) (result v128)
       local.get 0
-      i32x4.trunc_sat_f32x4_u)
-    (func $f32x4.convert_i32x4_s (type 10) (param v128) (result v128)
+      i32x4.trunc_sat_f32x4_u
+    )
+    (func $f32x4.convert_i32x4_s (;122;) (type 10) (param v128) (result v128)
       local.get 0
-      f32x4.convert_i32x4_s)
-    (func $f32x4.convert_i32x4_u (type 10) (param v128) (result v128)
+      f32x4.convert_i32x4_s
+    )
+    (func $f32x4.convert_i32x4_u (;123;) (type 10) (param v128) (result v128)
       local.get 0
-      f32x4.convert_i32x4_u)
-    (func $v128.const (type 0) (result v128)
-      v128.const i32x4 0x00000001 0x00000002 0x00000003 0x00000004)
+      f32x4.convert_i32x4_u
+    )
+    (func $v128.const (;124;) (type 0) (result v128)
+      v128.const i32x4 0x00000001 0x00000002 0x00000003 0x00000004
+    )
     (memory (;0;) 0)
     (export "v128.const" (func $v128.const))
     (export "v128.load" (func $v128.load))
@@ -1104,5 +1229,6 @@
     (export "i32x4_trunc_s_f32x4_sat" (func $i32x4_trunc_s_f32x4_sat))
     (export "i32x4_trunc_u_f32x4_sat" (func $i32x4_trunc_u_f32x4_sat))
     (export "f32x4.convert_i32x4_s" (func $f32x4.convert_i32x4_s))
-    (export "f32x4.convert_i32x4_u" (func $f32x4.convert_i32x4_u)))
+    (export "f32x4.convert_i32x4_u" (func $f32x4.convert_i32x4_u))
+  )
 ;)

--- a/crates/tests/tests/round_trip/start.wat
+++ b/crates/tests/tests/round_trip/start.wat
@@ -2,6 +2,10 @@
   (start 0)
   (func))
 
-;; CHECK: (module
-;; NEXT     (start 0)
-;; NEXT     (func))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func (;0;) (type 0))
+    (start 0)
+  )
+;)

--- a/crates/tests/tests/round_trip/stuff-after-loop-2.wat
+++ b/crates/tests/tests/round_trip/stuff-after-loop-2.wat
@@ -7,11 +7,15 @@
     i32.const 1)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      loop  ;; label = @1
-;; NEXT:        br 0 (;@1;)
-;; NEXT:      end
-;; NEXT:      i32.const 1)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      loop  ;; label = @1
+        br 0 (;@1;)
+      end
+      i32.const 1
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/stuff-after-loop-2.wat
+++ b/crates/tests/tests/round_trip/stuff-after-loop-2.wat
@@ -11,7 +11,7 @@
   (module
     (type (;0;) (func (result i32)))
     (func $f (;0;) (type 0) (result i32)
-      loop  ;; label = @1
+      loop ;; label = @1
         br 0 (;@1;)
       end
       i32.const 1

--- a/crates/tests/tests/round_trip/stuff-after-loop.wat
+++ b/crates/tests/tests/round_trip/stuff-after-loop.wat
@@ -10,7 +10,7 @@
   (module
     (type (;0;) (func (result i32)))
     (func $f (;0;) (type 0) (result i32)
-      loop  ;; label = @1
+      loop ;; label = @1
       end
       i32.const 1
     )

--- a/crates/tests/tests/round_trip/stuff-after-loop.wat
+++ b/crates/tests/tests/round_trip/stuff-after-loop.wat
@@ -6,10 +6,14 @@
     i32.const 1)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      loop  ;; label = @1
-;; NEXT:      end
-;; NEXT:      i32.const 1)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      loop  ;; label = @1
+      end
+      i32.const 1
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/table-init.wast
+++ b/crates/tests/tests/round_trip/table-init.wast
@@ -12,5 +12,6 @@
     (func (;0;) (type 0))
     (table (;0;) 1 funcref)
     (export "x" (table 0))
-    (elem (;0;) (global.get 0) func 0))
+    (elem (;0;) (global.get 0) func 0)
+  )
 ;)

--- a/crates/tests/tests/round_trip/type-deduplicate.wat
+++ b/crates/tests/tests/round_trip/type-deduplicate.wat
@@ -8,9 +8,12 @@
   (export "b" (func 1))
   )
 
-;; CHECK: (module
-;; NEXT:    (type
-;; NEXT:    (func
-;; NEXT:    (func
-;; NEXT:    (export
-;; NEXT:    (export
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func $f (;0;) (type 0))
+    (func (;1;) (type 0))
+    (export "a" (func $f))
+    (export "b" (func 1))
+  )
+;)

--- a/crates/tests/tests/round_trip/unreachable.wat
+++ b/crates/tests/tests/round_trip/unreachable.wat
@@ -4,8 +4,12 @@
     unreachable)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      unreachable)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      unreachable
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/unreachable_2.wat
+++ b/crates/tests/tests/round_trip/unreachable_2.wat
@@ -5,8 +5,12 @@
     i32.const 42)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      unreachable)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      unreachable
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/unreachable_3.wat
+++ b/crates/tests/tests/round_trip/unreachable_3.wat
@@ -14,7 +14,7 @@
   (module
     (type (;0;) (func (result i32)))
     (func $f (;0;) (type 0) (result i32)
-      block  ;; label = @1
+      block ;; label = @1
         unreachable
       end
       i32.const 42

--- a/crates/tests/tests/round_trip/unreachable_3.wat
+++ b/crates/tests/tests/round_trip/unreachable_3.wat
@@ -10,11 +10,15 @@
     i32.const 42)
   (export "f" (func $f)))
 
-;; CHECK: (module
-;; NEXT:    (type (;0;) (func (result i32)))
-;; NEXT:    (func $f (type 0) (result i32)
-;; NEXT:      block  ;; label = @1
-;; NEXT:        unreachable
-;; NEXT:      end
-;; NEXT:      i32.const 42)
-;; NEXT:    (export "f" (func $f)))
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      block  ;; label = @1
+        unreachable
+      end
+      i32.const 42
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/unreachable_4.wat
+++ b/crates/tests/tests/round_trip/unreachable_4.wat
@@ -4,5 +4,12 @@
     i32.add)
   (export "f" (func $f)))
 
-;; CHECK: (func $f (type 0) (result i32)
-;; NEXT:    unreachable)
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func (result i32)))
+    (func $f (;0;) (type 0) (result i32)
+      unreachable
+    )
+    (export "f" (func $f))
+  )
+;)

--- a/crates/tests/tests/round_trip/used-local-in-local.wat
+++ b/crates/tests/tests/round_trip/used-local-in-local.wat
@@ -7,7 +7,14 @@
   (export "foo" (func $foo))
   )
 
-;; CHECK: (func $foo
-;; NEXT:    (local i32 i32)
-;; NEXT:    local.get 0
-;; NEXT:    local.set 1)
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func $foo (;0;) (type 0)
+      (local i32 i32)
+      local.get 0
+      local.set 1
+    )
+    (export "foo" (func $foo))
+  )
+;)

--- a/crates/tests/tests/round_trip/used-local-set.wat
+++ b/crates/tests/tests/round_trip/used-local-set.wat
@@ -6,7 +6,15 @@
   (export "foo" (func $foo))
   )
 
-;; CHECK: (func $foo (type 0)
-;; NEXT:    (local i32)
-;; NEXT:    global.get 0
-;; NEXT:    local.set 0)
+(; CHECK-ALL:
+  (module
+    (type (;0;) (func))
+    (func $foo (;0;) (type 0)
+      (local i32)
+      global.get 0
+      local.set 0
+    )
+    (global (;0;) i32 i32.const 0)
+    (export "foo" (func $foo))
+  )
+;)


### PR DESCRIPTION
Many of the round-trip tests seem to be broken on master (mainly due to formatting changes). This change fixes the expected output so all tests now pass.

These changes were mostly done automatically, first by changing tests that use the `CHECK` and `NEXT` directives to use `CHECK-ALL`:

```
for f in $(rg -l NEXT crates/tests/tests/round_trip/)
do
    sed -i 's/;; CHECK: /(; CHECK-ALL:\n/' $f;
    sed -i 's/;; NEXT://' $f;
    echo ';)' >> $f;
done
```

and then updating the out put of those tests with
```
WALRUS_BLESS=1 cargo test --all
```