### PR TITLE
feat: dwarf code address mapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rayon = { version = "1.1.0", optional = true }
 walrus-macro = { path = './crates/macro', version = '=0.19.0' }
 wasm-encoder = "0.29.0"
 wasmparser = "0.80.2"
+gimli = "0.26.0"
 
 [features]
 parallel = ['rayon', 'id-arena/rayon']

--- a/crates/tests/tests/custom_sections.rs
+++ b/crates/tests/tests/custom_sections.rs
@@ -86,8 +86,8 @@ fn smoke_test_code_transform() {
 
         fn apply_code_transform(&mut self, transform: &CodeTransform) {
             APPLIED_CODE_TRANSFORM.store(1, Ordering::SeqCst);
-            assert!(!transform.is_empty());
-            for (input_offset, output_offset) in transform.iter().cloned() {
+            assert!(!transform.instruction_map.is_empty());
+            for (input_offset, output_offset) in transform.instruction_map.iter().cloned() {
                 assert_eq!(input_offset.data() as usize + 3, output_offset);
             }
         }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -120,7 +120,7 @@ impl From<TypeId> for InstrSeqType {
 }
 
 /// A symbolic original wasm operator source location.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub struct InstrLocId(u32);
 
 const DEFAULT_INSTR_LOC_ID: u32 = 0xffff_ffff;

--- a/src/module/debug/dwarf.rs
+++ b/src/module/debug/dwarf.rs
@@ -1,0 +1,406 @@
+//! transform entries in WebAssembly DWARF sections
+
+/// `write` provides only address-based entry conversions,
+/// does not provide entry-wise conversions.
+/// We want to convert addresses of instructions, here will re-implement.
+use gimli::*;
+
+/// DWARF convertion context
+pub(crate) struct ConvertContext<'a, R: Reader<Offset = usize>> {
+    /// Source DWARF debug data
+    pub debug_str: &'a read::DebugStr<R>,
+    pub debug_line_str: &'a read::DebugLineStr<R>,
+
+    /// Address conversion function
+    pub convert_address: &'a dyn Fn(u64, bool) -> Option<write::Address>,
+
+    pub line_strings: &'a mut write::LineStringTable,
+    pub strings: &'a mut write::StringTable,
+}
+
+impl<'a, R> ConvertContext<'a, R>
+where
+    R: Reader<Offset = usize>,
+{
+    pub(crate) fn new(
+        dwarf: &'a read::Dwarf<R>,
+        convert_address: &'a dyn Fn(u64, bool) -> Option<write::Address>,
+        line_strings: &'a mut write::LineStringTable,
+        strings: &'a mut write::StringTable,
+    ) -> Self {
+        ConvertContext {
+            debug_str: &dwarf.debug_str,
+            debug_line_str: &dwarf.debug_line_str,
+            convert_address,
+            line_strings,
+            strings,
+        }
+    }
+
+    pub(crate) fn convert_attributes(
+        &mut self,
+        from_unit: read::Unit<R>,
+    ) -> Option<write::LineProgram> {
+        match from_unit.line_program {
+            Some(ref from_program) => {
+                let from_program = from_program.clone();
+                let line_program = self
+                    .convert_line_program(from_program)
+                    .expect("cannot convert line program");
+                Some(line_program)
+            }
+            None => None,
+        }
+    }
+
+    /// Perform conversion in DWARF line program header.
+    /// Almostly cloned from https://github.com/gimli-rs/gimli/blob/master/src/write/line.rs#L985
+    fn convert_line_program_header(
+        &mut self,
+        from_program: &read::IncompleteLineProgram<R>,
+        dirs: &mut Vec<write::DirectoryId>,
+        files: &mut Vec<write::FileId>,
+    ) -> write::ConvertResult<write::LineProgram> {
+        let from_header = from_program.header();
+        let encoding = from_header.encoding();
+
+        let comp_dir = match from_header.directory(0) {
+            Some(comp_dir) => self.convert_line_string(comp_dir)?,
+            None => write::LineString::new(&[][..], encoding, &mut self.line_strings),
+        };
+
+        let (comp_name, comp_file_info) = match from_header.file(0) {
+            Some(comp_file) => {
+                if comp_file.directory_index() != 0 {
+                    return Err(write::ConvertError::InvalidDirectoryIndex);
+                }
+                (
+                    self.convert_line_string(comp_file.path_name())?,
+                    Some(write::FileInfo {
+                        timestamp: comp_file.timestamp(),
+                        size: comp_file.size(),
+                        md5: *comp_file.md5(),
+                    }),
+                )
+            }
+            None => (
+                write::LineString::new(&[][..], encoding, &mut self.line_strings),
+                None,
+            ),
+        };
+
+        if from_header.line_base() > 0 {
+            return Err(write::ConvertError::InvalidLineBase);
+        }
+        let mut program = write::LineProgram::new(
+            encoding,
+            from_header.line_encoding(),
+            comp_dir,
+            comp_name,
+            comp_file_info,
+        );
+
+        let file_skip = if from_header.version() <= 4 {
+            // The first directory is implicit.
+            dirs.push(program.default_directory());
+            // A file index of 0 is invalid for version <= 4, but putting
+            // something there makes the indexing easier.
+            0
+        } else {
+            // We don't add the first file to `files`, but still allow
+            // it to be referenced from converted instructions.
+            1
+        };
+
+        for from_dir in from_header.include_directories() {
+            let from_dir = self.convert_line_string(from_dir.clone())?;
+            dirs.push(program.add_directory(from_dir));
+        }
+
+        for from_file in from_header.file_names().iter().skip(file_skip) {
+            let from_name = self.convert_line_string(from_file.path_name())?;
+            let from_dir = from_file.directory_index();
+            if from_dir >= dirs.len() as u64 {
+                return Err(write::ConvertError::InvalidDirectoryIndex);
+            }
+            let from_dir = dirs[from_dir as usize];
+            let from_info = Some(write::FileInfo {
+                timestamp: from_file.timestamp(),
+                size: from_file.size(),
+                md5: *from_file.md5(),
+            });
+            files.push(program.add_file(from_name, from_dir, from_info));
+        }
+
+        Ok(program)
+    }
+
+    /// Perform address conversion in DWARF line program entries.
+    /// Almostly cloned from https://github.com/gimli-rs/gimli/blob/master/src/write/line.rs#L1066
+    fn convert_line_program(
+        &mut self,
+        mut from_program: read::IncompleteLineProgram<R>,
+    ) -> write::ConvertResult<write::LineProgram> {
+        let mut dirs = Vec::new();
+        let mut files = Vec::new();
+        // Create mappings in case the source has duplicate files or directories.
+        let mut program = self
+            .convert_line_program_header(&from_program, &mut dirs, &mut files)
+            .expect("");
+
+        // We can't use the `from_program.rows()` because that wouldn't let
+        // us preserve address relocations.
+        let mut from_row = read::LineRow::new(from_program.header());
+        let mut instructions = from_program.header().instructions();
+        let mut next_sequence_base_address = None;
+        let mut from_base_address = 0;
+        let mut base_address = 0;
+        let mut previous_from_raw_address_offset = 0;
+        let mut previous_raw_address = 0;
+        let mut non_existent_symbol = false;
+        while let Some(instruction) = instructions.next_instruction(from_program.header())? {
+            match instruction {
+                read::LineInstruction::SetAddress(val) => {
+                    if program.in_sequence() {
+                        return Err(write::ConvertError::UnsupportedLineInstruction);
+                    }
+                    match (self.convert_address)(val, false) {
+                        Some(converted) => {
+                            next_sequence_base_address = Some(converted);
+                            from_base_address = val;
+                            previous_from_raw_address_offset = 0;
+                            non_existent_symbol = false;
+                        }
+                        None => {
+                            non_existent_symbol = true;
+                        }
+                    }
+                    from_row.execute(read::LineInstruction::SetAddress(0), &mut from_program);
+                }
+                read::LineInstruction::DefineFile(_) => {
+                    return Err(write::ConvertError::UnsupportedLineInstruction);
+                }
+                _ => {
+                    if from_row.execute(instruction, &mut from_program) {
+                        if !non_existent_symbol {
+                            if !program.in_sequence() {
+                                program.begin_sequence(next_sequence_base_address);
+                                if let Some(write::Address::Constant(raw_address)) =
+                                    next_sequence_base_address
+                                {
+                                    base_address = raw_address;
+                                    previous_raw_address = 0;
+                                }
+                                next_sequence_base_address = None;
+                            }
+                            let from_row_address = from_row.address() + from_base_address;
+                            let row_address = if let Some(write::Address::Constant(address)) =
+                                (self.convert_address)(from_row_address, true)
+                            {
+                                address
+                            } else {
+                                let from_row_address_advance =
+                                    from_row.address() - previous_from_raw_address_offset;
+                                previous_raw_address + from_row_address_advance
+                            };
+                            previous_from_raw_address_offset = from_row.address();
+                            previous_raw_address = row_address;
+
+                            if from_row.end_sequence() {
+                                program.end_sequence(row_address);
+                                next_sequence_base_address =
+                                    (self.convert_address)(from_row_address, false);
+                            } else {
+                                program.row().address_offset = row_address - base_address;
+                                program.row().op_index = from_row.op_index();
+                                program.row().file = {
+                                    let file = from_row.file_index();
+                                    if file > files.len() as u64 {
+                                        return Err(write::ConvertError::InvalidFileIndex);
+                                    }
+                                    if file == 0 && program.version() <= 4 {
+                                        return Err(write::ConvertError::InvalidFileIndex);
+                                    }
+                                    files[(file - 1) as usize]
+                                };
+                                program.row().line = match from_row.line() {
+                                    Some(line) => line.get(),
+                                    None => 0,
+                                };
+                                program.row().column = match from_row.column() {
+                                    read::ColumnType::LeftEdge => 0,
+                                    read::ColumnType::Column(val) => val.get(),
+                                };
+                                program.row().discriminator = from_row.discriminator();
+                                program.row().is_statement = from_row.is_stmt();
+                                program.row().basic_block = from_row.basic_block();
+                                program.row().prologue_end = from_row.prologue_end();
+                                program.row().epilogue_begin = from_row.epilogue_begin();
+                                program.row().isa = from_row.isa();
+                                program.generate_row();
+                            }
+                        }
+                        from_row.reset(from_program.header());
+                    }
+                }
+            };
+        }
+        Ok(program)
+    }
+
+    /// Almostly cloned from https://github.com/gimli-rs/gimli/blob/master/src/write/line.rs#L1131
+    fn convert_line_string(
+        &mut self,
+        from_attr: read::AttributeValue<R>,
+    ) -> write::ConvertResult<write::LineString> {
+        Ok(match from_attr {
+            read::AttributeValue::String(r) => write::LineString::String(r.to_slice()?.to_vec()),
+            read::AttributeValue::DebugStrRef(offset) => {
+                let r = self.debug_str.get_str(offset)?;
+                let id = self.strings.add(r.to_slice()?);
+                write::LineString::StringRef(id)
+            }
+            read::AttributeValue::DebugLineStrRef(offset) => {
+                let r = self.debug_line_str.get_str(offset)?;
+                let id = self.line_strings.add(r.to_slice()?);
+                write::LineString::LineStringRef(id)
+            }
+            _ => return Err(write::ConvertError::UnsupportedLineStringForm),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gimli::*;
+    use std::cell::RefCell;
+
+    fn make_test_debug_line<'a>(
+        debug_line: &'a mut write::DebugLine<write::EndianVec<LittleEndian>>,
+        make_line_row: &'a dyn Fn(&mut write::LineProgram) -> (),
+    ) -> IncompleteLineProgram<EndianSlice<'a, LittleEndian>> {
+        let encoding = Encoding {
+            format: Format::Dwarf32,
+            version: 4,
+            address_size: 4,
+        };
+        let dir1 = &b"dir1"[..];
+        let file1 = &b"file1"[..];
+        let comp_dir = write::LineString::String(dir1.to_vec());
+        let comp_file = write::LineString::String(file1.to_vec());
+
+        let mut program = write::LineProgram::new(
+            encoding,
+            LineEncoding {
+                minimum_instruction_length: 1,
+                maximum_operations_per_instruction: 8,
+                line_base: 0,
+                line_range: 10,
+                default_is_stmt: true,
+            },
+            comp_dir.clone(),
+            comp_file.clone(),
+            None,
+        );
+
+        {
+            program.row().file = program.add_file(comp_file, program.default_directory(), None);
+            make_line_row(&mut program);
+        }
+
+        {
+            let debug_line_str_offsets = write::DebugLineStrOffsets::none();
+            let debug_str_offsets = write::DebugStrOffsets::none();
+            program
+                .write(
+                    debug_line,
+                    encoding,
+                    &debug_line_str_offsets,
+                    &debug_str_offsets,
+                )
+                .unwrap();
+        }
+
+        let debug_line = read::DebugLine::new(debug_line.slice(), LittleEndian);
+        let incomplete_debug_line = debug_line
+            .program(DebugLineOffset(0), 4, None, None)
+            .unwrap();
+
+        incomplete_debug_line
+    }
+
+    #[test]
+    fn convert_context() {
+        let called_address_to_be_converted: RefCell<Vec<(u64, bool)>> = RefCell::new(Vec::new());
+
+        let mut debug_line = write::DebugLine::from(write::EndianVec::new(LittleEndian));
+        let mut converted_debug_line = write::DebugLine::from(write::EndianVec::new(LittleEndian));
+
+        {
+            let make_line_row = |program: &mut write::LineProgram| {
+                program.begin_sequence(Some(write::Address::Constant(0x1000)));
+                program.generate_row();
+                let address_offset = program.row().address_offset + 1u64;
+                program.end_sequence(address_offset);
+            };
+            let incomplete_debug_line = make_test_debug_line(&mut debug_line, &make_line_row);
+
+            let convert_address = |address, edge_is_previous| -> Option<write::Address> {
+                called_address_to_be_converted
+                    .borrow_mut()
+                    .push((address, edge_is_previous));
+                Some(write::Address::Constant(address + 0x10))
+            };
+
+            let empty_dwarf = Dwarf::load(|_| -> Result<EndianSlice<LittleEndian>> {
+                Ok(EndianSlice::new(&[], LittleEndian))
+            })
+            .unwrap();
+
+            let mut line_strings = write::LineStringTable::default();
+            let mut strings = write::StringTable::default();
+            let mut convert_context = crate::module::debug::ConvertContext::new(
+                &empty_dwarf,
+                &convert_address,
+                &mut line_strings,
+                &mut strings,
+            );
+            let converted_program = convert_context
+                .convert_line_program(incomplete_debug_line)
+                .unwrap();
+
+            converted_program
+                .write(
+                    &mut converted_debug_line,
+                    Encoding {
+                        format: Format::Dwarf32,
+                        version: 4,
+                        address_size: 4,
+                    },
+                    &write::DebugLineStrOffsets::none(),
+                    &write::DebugStrOffsets::none(),
+                )
+                .unwrap();
+        }
+
+        {
+            let called_address_to_be_converted = called_address_to_be_converted.borrow();
+            assert_eq!(called_address_to_be_converted.len(), 4);
+            assert_eq!(called_address_to_be_converted[0], (0x1000, false)); // begin sequence
+            assert_eq!(called_address_to_be_converted[1], (0x1000, true)); // first line row
+            assert_eq!(called_address_to_be_converted[2], (0x1001, true)); // end sequence
+            assert_eq!(called_address_to_be_converted[3], (0x1001, false)); // calculation of next entry address
+        }
+
+        {
+            let read_debug_line = read::DebugLine::new(converted_debug_line.slice(), LittleEndian);
+            let read_program = read_debug_line
+                .program(DebugLineOffset(0), 4, None, None)
+                .unwrap();
+
+            let mut rows = read_program.rows();
+            let row = rows.next_row().unwrap().unwrap().1;
+            assert_eq!(row.address(), 0x1010);
+        }
+    }
+}

--- a/src/module/debug/mod.rs
+++ b/src/module/debug/mod.rs
@@ -1,0 +1,274 @@
+mod dwarf;
+
+use crate::emit::{Emit, EmitContext};
+use crate::{CustomSection, Function, InstrLocId, Module, ModuleFunctions, RawCustomSection};
+use gimli::*;
+use id_arena::Id;
+use std::cmp::Ordering;
+
+use self::dwarf::ConvertContext;
+
+/// The DWARF debug section in input WebAssembly binary.
+#[derive(Debug, Default)]
+pub struct ModuleDebugData {
+    /// DWARF debug data
+    pub dwarf: read::Dwarf<Vec<u8>>,
+}
+
+/// Specify roles of origial address.
+
+#[derive(Debug, PartialEq)]
+enum CodeAddress {
+    /// The address is instruction within a function.
+    InstrInFunction { instr_id: InstrLocId },
+    /// The address is within a function, but does not match any instruction.
+    OffsetInFunction { id: Id<Function>, offset: usize },
+    /// The address is boundary of functions. Equals to OffsetInFunction with offset(section size).
+    FunctionEdge { id: Id<Function> },
+    /// The address is unknown.
+    Unknown,
+}
+
+/// Converts original code address to CodeAddress
+struct CodeAddressConverter {
+    /// Function range based convert table
+    address_convert_table: Vec<(wasmparser::Range, Id<Function>)>,
+    /// Instrument based convert table
+    instrument_address_convert_table: Vec<(usize, InstrLocId)>,
+}
+
+impl CodeAddressConverter {
+    fn from_emit_context(funcs: &ModuleFunctions) -> Self {
+        let mut address_convert_table = funcs
+            .iter_local()
+            .filter_map(|(func_id, func)| func.original_range.map(|range| (range, func_id)))
+            .collect::<Vec<_>>();
+
+        let mut instrument_address_convert_table = funcs
+            .iter_local()
+            .map(|(_, func)| &func.instruction_mapping)
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>();
+
+        address_convert_table.sort_by_key(|i| i.0.start);
+        instrument_address_convert_table.sort_by_key(|i| i.0);
+
+        Self {
+            address_convert_table,
+            instrument_address_convert_table,
+        }
+    }
+
+    fn find_address(&self, address: usize, edge_is_previous: bool) -> CodeAddress {
+        if let Ok(id) = self
+            .instrument_address_convert_table
+            .binary_search_by_key(&address, |i| i.0)
+        {
+            return CodeAddress::InstrInFunction {
+                instr_id: self.instrument_address_convert_table[id].1,
+            };
+        }
+
+        let previous_range_comparor = |range: &(wasmparser::Range, Id<Function>)| {
+            if range.0.end < address {
+                Ordering::Less
+            } else if address <= range.0.start {
+                Ordering::Greater
+            } else {
+                Ordering::Equal
+            }
+        };
+        let next_range_comparor = |range: &(wasmparser::Range, Id<Function>)| {
+            if range.0.end <= address {
+                Ordering::Less
+            } else if address < range.0.start {
+                Ordering::Greater
+            } else {
+                Ordering::Equal
+            }
+        };
+        let range_comparor: &dyn Fn(_) -> Ordering = if edge_is_previous {
+            &previous_range_comparor
+        } else {
+            &next_range_comparor
+        };
+
+        match self.address_convert_table.binary_search_by(range_comparor) {
+            Ok(i) => {
+                let entry = &self.address_convert_table[i];
+                let code_offset_from_function_start = address - entry.0.start;
+
+                if code_offset_from_function_start == entry.0.end - entry.0.start {
+                    CodeAddress::FunctionEdge { id: entry.1 }
+                } else {
+                    CodeAddress::OffsetInFunction {
+                        id: entry.1,
+                        offset: code_offset_from_function_start,
+                    }
+                }
+            }
+            Err(_) => CodeAddress::Unknown,
+        }
+    }
+}
+
+impl Module {
+    pub(crate) fn parse_debug_sections(
+        &mut self,
+        mut debug_sections: Vec<RawCustomSection>,
+    ) -> Result<()> {
+        let load_section = |id: gimli::SectionId| -> Result<Vec<u8>> {
+            Ok(
+                match debug_sections
+                    .iter_mut()
+                    .find(|section| section.name() == id.name())
+                {
+                    Some(section) => std::mem::take(&mut section.data),
+                    None => Vec::new(),
+                },
+            )
+        };
+
+        self.debug.dwarf = read::Dwarf::load(load_section)?;
+
+        Ok(())
+    }
+}
+
+impl Emit for ModuleDebugData {
+    fn emit(&self, cx: &mut EmitContext) {
+        let address_converter = CodeAddressConverter::from_emit_context(&cx.module.funcs);
+
+        let code_transform = &cx.code_transform;
+        let instruction_map = &code_transform.instruction_map;
+
+        let convert_address = |address, edge_is_previous| -> Option<write::Address> {
+            let address = address as usize;
+            let address = match address_converter.find_address(address, edge_is_previous) {
+                CodeAddress::InstrInFunction { instr_id } => {
+                    match instruction_map.binary_search_by_key(&instr_id, |i| i.0) {
+                        Ok(id) => Some(instruction_map[id].1),
+                        Err(_) => None,
+                    }
+                }
+                CodeAddress::OffsetInFunction { id, offset } => {
+                    match code_transform
+                        .function_ranges
+                        .binary_search_by_key(&id, |i| i.0)
+                    {
+                        Ok(id) => Some(code_transform.function_ranges[id].1.start + offset),
+                        Err(_) => None,
+                    }
+                }
+                CodeAddress::FunctionEdge { id } => {
+                    match code_transform
+                        .function_ranges
+                        .binary_search_by_key(&id, |i| i.0)
+                    {
+                        Ok(id) => {
+                            if edge_is_previous {
+                                Some(code_transform.function_ranges[id].1.end)
+                            } else {
+                                Some(code_transform.function_ranges[id].1.start)
+                            }
+                        }
+                        Err(_) => None,
+                    }
+                }
+                CodeAddress::Unknown => None,
+            };
+
+            address
+                .map(|x| (x - cx.code_transform.code_section_start) as u64)
+                .map(write::Address::Constant)
+        };
+
+        let from_dwarf = cx
+            .module
+            .debug
+            .dwarf
+            .borrow(|sections| EndianSlice::new(sections.as_ref(), LittleEndian));
+
+        let mut dwarf = write::Dwarf::from(&from_dwarf, &|address| {
+            convert_address(address, true).or(Some(write::Address::Constant(0)))
+        })
+        .expect("cannot convert to writable dwarf");
+
+        let mut from_units = from_dwarf.units();
+        let mut unit_entries = Vec::new();
+
+        while let Some(from_unit) = from_units.next().expect("") {
+            unit_entries.push(from_unit);
+        }
+
+        let mut convert_context = ConvertContext::new(
+            &from_dwarf,
+            &convert_address,
+            &mut dwarf.line_strings,
+            &mut dwarf.strings,
+        );
+
+        for index in 0..dwarf.units.count() {
+            let id = dwarf.units.id(index);
+            let unit = dwarf.units.get_mut(id);
+
+            if let Some(program) =
+                convert_context.convert_attributes(from_dwarf.unit(unit_entries[index]).expect(""))
+            {
+                unit.line_program = program;
+            }
+        }
+
+        let mut sections = write::Sections::new(write::EndianVec::new(gimli::LittleEndian));
+        dwarf.write(&mut sections).expect("write failed");
+        sections
+            .for_each(
+                |id: SectionId, data: &write::EndianVec<LittleEndian>| -> Result<()> {
+                    cx.wasm_module.section(&wasm_encoder::CustomSection {
+                        name: id.name().into(),
+                        data: data.slice().into(),
+                    });
+                    Ok(())
+                },
+            )
+            .expect("never");
+    }
+}
+
+#[test]
+fn dwarf_address_converter() {
+    let mut module = crate::Module::default();
+
+    let mut func = crate::LocalFunction::new(
+        Vec::new(),
+        crate::FunctionBuilder::new(&mut module.types, &[], &[]),
+    );
+
+    func.original_range = Some(wasmparser::Range { start: 20, end: 30 });
+
+    let id = module.funcs.add_local(func);
+
+    let address_converter = CodeAddressConverter::from_emit_context(&module.funcs);
+
+    assert_eq!(
+        address_converter.find_address(10, true),
+        CodeAddress::Unknown
+    );
+    assert_eq!(
+        address_converter.find_address(25, true),
+        CodeAddress::OffsetInFunction { id, offset: 5 }
+    );
+    assert_eq!(
+        address_converter.find_address(30, true),
+        CodeAddress::FunctionEdge { id }
+    );
+    assert_eq!(
+        address_converter.find_address(30, false),
+        CodeAddress::Unknown
+    );
+    assert_eq!(
+        address_converter.find_address(31, true),
+        CodeAddress::Unknown
+    );
+}


### PR DESCRIPTION
This is a rebase of the PR at https://github.com/rustwasm/walrus/pull/231 to the current main branch, created by @nokotan.

I didn't want to push over that branch, especially since it seems to be in use in various integration attempts. From the description there -

This is experiment implementation of transforming DWARF debug entries in WebAssembly binaries.

It seems to require more difficult implementation that using intermediate DWARF expression with [gimli.rs](https://github.com/gimli-rs/gimli), does not have direct access DWARF entries to be written.
This PR contains simpler way to transform code address:

- Instruction mapped address conversion
- Function code range based address conversion

Milestones

- [x] Function code range based address conversion
- [x] Implement instruction mapped address conversion
- [x] Better expression of code address that does not exactly match to instruction
  - beginning or end of function
- [x] Implement test cases
