### PR TITLE
fix(tests): update WAT used in tests

### DIFF
--- a/crates/tests/tests/invalid/multi-value-0.wat
+++ b/crates/tests/tests/invalid/multi-value-0.wat
@@ -2,4 +2,4 @@
   (func (export "i64.dup") (param i64) (result i64 i64)
     ;; With this commented out, there's only a single i64 on the stack.
     ;; get_local 0
-    get_local 0))
+    (local.get 0)))

--- a/crates/tests/tests/invalid/multi-value-1.wat
+++ b/crates/tests/tests/invalid/multi-value-1.wat
@@ -1,6 +1,6 @@
 (module
   (func (export "i64.dup") (param i64) (result i64 i64)
     ;; Too many i64s on the stack.
-    get_local 0
-    get_local 0
-    get_local 0))
+    (local.get 0)
+    (local.get 0)
+    (local.get 0)))

--- a/crates/tests/tests/round_trip/atomic.wat
+++ b/crates/tests/tests/round_trip/atomic.wat
@@ -11,17 +11,17 @@
       (i32.const 0)
       (i32.const 1))
 
-    (atomic.notify
+    (memory.atomic.notify
       (i32.const 0)
       (i32.const 1))
 
-    (i32.atomic.wait
+    (memory.atomic.wait32
       (i32.const 0)
       (i32.const 1)
       (i64.const 2)
       )
 
-    (i64.atomic.wait
+    (memory.atomic.wait64
       (i32.const 0)
       (i64.const 1)
       (i64.const 2)

--- a/crates/tests/tests/round_trip/fac-multi-value.wat
+++ b/crates/tests/tests/round_trip/fac-multi-value.wat
@@ -1,13 +1,13 @@
 (module
   ;; Iterative factorial without locals.
   (func $pick0 (param i64) (result i64 i64)
-    (get_local 0) (get_local 0)
+    (local.get 0) (local.get 0)
   )
   (func $pick1 (param i64 i64) (result i64 i64 i64)
-    (get_local 0) (get_local 1) (get_local 0)
+    (local.get 0) (local.get 1) (local.get 0)
   )
   (func (export "fac-ssa") (param i64) (result i64)
-    (i64.const 1) (get_local 0)
+    (i64.const 1) (local.get 0)
     (loop $l (param i64 i64) (result i64)
       (call $pick1) (call $pick1) (i64.mul)
       (call $pick1) (i64.const 1) (i64.sub)

--- a/crates/tests/tests/round_trip/multi-0.wat
+++ b/crates/tests/tests/round_trip/multi-0.wat
@@ -1,6 +1,6 @@
 (module
   (func (export "i64.dup") (param i64) (result i64 i64)
-    (get_local 0) (get_local 0)))
+    (local.get 0) (local.get 0)))
 
 (; CHECK-ALL:
   (module

--- a/crates/tests/tests/valid/fac-multi-value.wat
+++ b/crates/tests/tests/valid/fac-multi-value.wat
@@ -3,13 +3,13 @@
 (module
   ;; Iterative factorial without locals.
   (func $pick0 (param i64) (result i64 i64)
-    (get_local 0) (get_local 0)
+    (local.get 0) (local.get 0)
   )
   (func $pick1 (param i64 i64) (result i64 i64 i64)
-    (get_local 0) (get_local 1) (get_local 0)
+    (local.get 0) (local.get 1) (local.get 0)
   )
   (func (export "fac-ssa") (param i64) (result i64)
-    (i64.const 1) (get_local 0)
+    (i64.const 1) (local.get 0)
     (loop $l (param i64 i64) (result i64)
       (call $pick1) (call $pick1) (i64.mul)
       (call $pick1) (i64.const 1) (i64.sub)


### PR DESCRIPTION
The excellent pre-existing test suite contains a lot of WAT files as test-cases that seem to have older syntax in them.

The breakage is introduced because the current test suite runs stable, latest and nightly versions of Rust while conducting tests. While the rest of the Wasm toolchain (binaryen, wabt, etc) are hard-coded to versions that should stay compatible with the WAT as they were written, the upstreaming of various changes to Rust itself seems to be causing failures when using the existing WAT for tests.

This PR updates the WAT (mostly operation renaming) that have changed in order to get the [`stable`|`beta`|`nightly`] tests passing again.