### PR TITLE
refactor: improve ergonomics of fn replace

### DIFF
--- a/crates/tests/tests/spec-tests.rs
+++ b/crates/tests/tests/spec-tests.rs
@@ -124,13 +124,13 @@ fn run(wast: &Path) -> Result<(), anyhow::Error> {
                 let wasm = fs::read(&path)?;
                 let mut wasm = config
                     .parse(&wasm)
-                    .context(format!("error parsing wasm (line {})", line))?;
+                    .with_context(|| format!("error parsing wasm (line {})", line))?;
                 let wasm1 = wasm.emit_wasm();
                 fs::write(&path, &wasm1)?;
                 let wasm2 = config
                     .parse(&wasm1)
                     .map(|mut m| m.emit_wasm())
-                    .context(format!("error re-parsing wasm (line {})", line))?;
+                    .with_context(|| format!("error re-parsing wasm (line {})", line))?;
                 if wasm1 != wasm2 {
                     panic!("wasm module at line {} isn't deterministic", line);
                 }

--- a/src/module/exports.rs
+++ b/src/module/exports.rs
@@ -135,6 +135,20 @@ impl ModuleExports {
             _ => false,
         })
     }
+
+    /// Delete an exported function by name from this module.
+    pub fn delete_func_by_name(&mut self, name: impl AsRef<str>) -> Result<()> {
+        let fid = self.get_func_by_name(name.as_ref()).context(format!(
+            "failed to find exported func with name [{}]",
+            name.as_ref()
+        ))?;
+        self.delete(
+            self.get_exported_func(fid)
+                .with_context(|| format!("failed to find exported func with ID [{fid:?}]"))?
+                .id(),
+        );
+        Ok(())
+    }
 }
 
 impl Module {

--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -130,6 +130,25 @@ impl ModuleImports {
             _ => None,
         })
     }
+
+    /// Delete an imported function by name from this module.
+    pub fn delete_func_by_name(
+        &mut self,
+        module: impl AsRef<str>,
+        name: impl AsRef<str>,
+    ) -> Result<()> {
+        let fid = self
+            .get_func_by_name(module, name.as_ref())
+            .with_context(|| {
+                format!("failed to find imported func with name [{}]", name.as_ref())
+            })?;
+        self.delete(
+            self.get_imported_func(fid)
+                .with_context(|| format!("failed to find imported func with ID [{fid:?}]"))?
+                .id(),
+        );
+        Ok(())
+    }
 }
 
 impl Module {

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -27,6 +27,7 @@ pub use crate::module::debug::ModuleDebugData;
 pub use crate::module::elements::ElementKind;
 pub use crate::module::elements::{Element, ElementId, ModuleElements};
 pub use crate::module::exports::{Export, ExportId, ExportItem, ModuleExports};
+pub use crate::module::functions::{FuncParams, FuncResults};
 pub use crate::module::functions::{Function, FunctionId, ModuleFunctions};
 pub use crate::module::functions::{FunctionKind, ImportedFunction, LocalFunction};
 pub use crate::module::globals::{Global, GlobalId, GlobalKind, ModuleGlobals};


### PR DESCRIPTION
After trialing `replace_(imported|exported)_func` in WASI-Virt, it's clear that the ergonomics around the builder function need to be improved. `FunctionBuilder` (particularly `FunctionBuilder::new()`) is difficult to use without a mutable borrow of the module itself.

This commit refactors `replace_(imported|exported)_func` in order to pass through the mutable borrow which makes it easier to use `FunctionBuilder`s.