### PR TITLE
fix: delete_func_by_name in `ModuleImports`/`ModuleExports`

### DIFF
--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -137,16 +137,23 @@ impl ModuleImports {
         module: impl AsRef<str>,
         name: impl AsRef<str>,
     ) -> Result<()> {
-        let fid = self
-            .get_func_by_name(module, name.as_ref())
+        let import = self
+            .iter()
+            .find(|e| e.module == module.as_ref() && e.name == name.as_ref())
             .with_context(|| {
                 format!("failed to find imported func with name [{}]", name.as_ref())
             })?;
-        self.delete(
-            self.get_imported_func(fid)
-                .with_context(|| format!("failed to find imported func with ID [{fid:?}]"))?
-                .id(),
-        );
+
+        if let ImportKind::Function(_) = import.kind {
+            self.delete(import.id());
+        } else {
+            bail!(
+                "import [{}] in module [{}] is not an imported function",
+                name.as_ref(),
+                module.as_ref()
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
The functions `ModuleExports::delete_func_by_name` and `ModuleImports::delete_func_by_name` were broken due to the possibility of the *same* function ID being used in *multiple* exports.

Since the code was getting the "first" function ID it found with a matching name (or name & module in the case of imports), deleting that export could mean deleting a *different* export ahead of time.

A worked example:
- export "A" w/ ID 24 exists, tied to fn 48
- export "B" w/ ID 99 exists, tied to fn 48

Things are fine when we use the export name "A" to get the relevant function ID, but when we use that ID to *look up* an export, it's unclear which one we will get -- searching by function ID would surface *either* existing export. The existing functions don't actually account for this possibility at all (they just happily return the "first" one).

This commit fixes this by changing the logic of `delete_func_by_name` to use *only* the export name, and do manual checking for whether the export/import is a function.