### PR TITLE
rename: get_func_by_name to get_func

### DIFF
--- a/src/module/exports.rs
+++ b/src/module/exports.rs
@@ -102,8 +102,8 @@ impl ModuleExports {
         })
     }
 
-    /// Retrieve an exported function by name
-    pub fn get_func_by_name(&self, name: impl AsRef<str>) -> Result<FunctionId> {
+    /// Retrieve an exported function by export name
+    pub fn get_func(&self, name: impl AsRef<str>) -> Result<FunctionId> {
         self.iter()
             .find_map(|expt| match expt.item {
                 ExportItem::Function(fid) if expt.name == name.as_ref() => Some(fid),
@@ -136,8 +136,8 @@ impl ModuleExports {
         })
     }
 
-    /// Delete an exported function by name from this module.
-    pub fn delete_func_by_name(&mut self, name: impl AsRef<str>) -> Result<()> {
+    /// Delete an export by name from this module.
+    pub fn remove(&mut self, name: impl AsRef<str>) -> Result<()> {
         let export = self
             .iter()
             .find(|e| e.name == name.as_ref())
@@ -145,11 +145,7 @@ impl ModuleExports {
                 format!("failed to find exported func with name [{}]", name.as_ref())
             })?;
 
-        if let ExportItem::Function(_) = export.item {
-            self.delete(export.id());
-        } else {
-            bail!("export [{}] is not an exported function", name.as_ref());
-        }
+        self.delete(export.id());
 
         Ok(())
     }
@@ -389,9 +385,9 @@ mod tests {
         let mut module = Module::default();
         let fn_id: FunctionId = always_the_same_id();
         let export_id: ExportId = module.exports.add("dummy", fn_id);
-        assert!(module.exports.get_func_by_name("dummy").is_ok());
+        assert!(module.exports.get_func("dummy").is_ok());
         module.exports.delete(export_id);
-        assert!(module.exports.get_func_by_name("dummy").is_err());
+        assert!(module.exports.get_func("dummy").is_err());
     }
 
     #[test]

--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -105,12 +105,8 @@ impl ModuleImports {
         Some(import?.0)
     }
 
-    /// Retrieve an imported function by name, including the module in which it resides
-    pub fn get_func_by_name(
-        &self,
-        module: impl AsRef<str>,
-        name: impl AsRef<str>,
-    ) -> Result<FunctionId> {
+    /// Retrieve an imported function by import name, including the module in which it resides
+    pub fn get_func(&self, module: impl AsRef<str>, name: impl AsRef<str>) -> Result<FunctionId> {
         self.iter()
             .find_map(|impt| match impt.kind {
                 ImportKind::Function(fid)
@@ -132,11 +128,7 @@ impl ModuleImports {
     }
 
     /// Delete an imported function by name from this module.
-    pub fn delete_func_by_name(
-        &mut self,
-        module: impl AsRef<str>,
-        name: impl AsRef<str>,
-    ) -> Result<()> {
+    pub fn remove(&mut self, module: impl AsRef<str>, name: impl AsRef<str>) -> Result<()> {
         let import = self
             .iter()
             .find(|e| e.module == module.as_ref() && e.name == name.as_ref())
@@ -144,15 +136,7 @@ impl ModuleImports {
                 format!("failed to find imported func with name [{}]", name.as_ref())
             })?;
 
-        if let ImportKind::Function(_) = import.kind {
-            self.delete(import.id());
-        } else {
-            bail!(
-                "import [{}] in module [{}] is not an imported function",
-                name.as_ref(),
-                module.as_ref()
-            );
-        }
+        self.delete(import.id());
 
         Ok(())
     }
@@ -395,7 +379,7 @@ mod tests {
 
         assert!(module
             .imports
-            .get_func_by_name("mod", "dummy")
+            .get_func("mod", "dummy")
             .is_ok_and(|fid| fid == new_fn_id));
     }
 }


### PR DESCRIPTION
This renames the new `(imports|exports).get_func_by_name` to just `(imports|exports).get_func`. The main reason being that I think the `by_name` term is overloaded in the functions list already to mean the actual function name instead of the import or export name, so wanted to avoid any confusion here.

Then I updated the `delete_by_name` functions to be generic named `remove` functions also without the `by_name` term to avoid confusion about it.

