### PR TITLE
Resolve more translated address in DWARF debug info

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -163,6 +163,9 @@ pub struct InstrSeq {
 
     /// The instructions that make up the body of this block.
     pub instrs: Vec<(Instr, InstrLocId)>,
+
+    /// For code address mapping
+    pub end: InstrLocId,
 }
 
 impl Deref for InstrSeq {
@@ -185,7 +188,13 @@ impl InstrSeq {
     /// Construct a new instruction sequence.
     pub(crate) fn new(id: InstrSeqId, ty: InstrSeqType) -> InstrSeq {
         let instrs = vec![];
-        InstrSeq { id, ty, instrs }
+        let end = Default::default();
+        InstrSeq {
+            id,
+            ty,
+            instrs,
+            end,
+        }
     }
 
     /// Get the id of this instruction sequence.

--- a/src/module/debug/dwarf.rs
+++ b/src/module/debug/dwarf.rs
@@ -13,6 +13,8 @@ pub enum AddressSearchPreference {
     InclusiveFunctionEnd,
 }
 
+pub(crate) static DEAD_CODE: u64 = 0xFFFFFFFF;
+
 /// DWARF convertion context
 pub(crate) struct ConvertContext<'a, R: Reader<Offset = usize>> {
     /// Source DWARF debug data

--- a/src/module/debug/expression.rs
+++ b/src/module/debug/expression.rs
@@ -1,0 +1,300 @@
+use crate::{CodeTransform, Function, InstrLocId, ModuleFunctions};
+use id_arena::Id;
+use std::cmp::Ordering;
+
+use super::dwarf::AddressSearchPreference;
+
+/// Specify roles of origial address.
+#[derive(Debug, PartialEq)]
+pub(crate) enum CodeAddress {
+    /// The address is instruction within a function.
+    InstrInFunction { instr_id: InstrLocId },
+    /// The address is one byte before the instruction.
+    InstrEdge { instr_id: InstrLocId },
+    /// The address is within a function, but does not match any instruction.
+    OffsetInFunction { id: Id<Function>, offset: usize },
+    /// The address is boundary of functions. Equals to OffsetInFunction with offset(section size).
+    FunctionEdge { id: Id<Function> },
+    /// The address is unknown.
+    Unknown,
+}
+
+/// Converts original code address to CodeAddress
+pub(crate) struct CodeAddressGenerator {
+    /// Function range based convert table
+    address_convert_table: Vec<(wasmparser::Range, Id<Function>)>,
+    /// Instrument based convert table
+    instrument_address_convert_table: Vec<(usize, InstrLocId)>,
+}
+
+impl CodeAddressGenerator {
+    pub(crate) fn new(funcs: &ModuleFunctions) -> Self {
+        let mut address_convert_table = funcs
+            .iter_local()
+            .filter_map(|(func_id, func)| func.original_range.map(|range| (range, func_id)))
+            .collect::<Vec<_>>();
+
+        let mut instrument_address_convert_table = funcs
+            .iter_local()
+            .flat_map(|(_, func)| &func.instruction_mapping)
+            .copied()
+            .collect::<Vec<_>>();
+
+        address_convert_table.sort_by_key(|i| i.0.start);
+        instrument_address_convert_table.sort_by_key(|i| i.0);
+
+        Self {
+            address_convert_table,
+            instrument_address_convert_table,
+        }
+    }
+
+    pub(crate) fn find_address(
+        &self,
+        address: usize,
+        search_preference: AddressSearchPreference,
+    ) -> CodeAddress {
+        match self
+            .instrument_address_convert_table
+            .binary_search_by_key(&address, |i| i.0)
+        {
+            Ok(id) => {
+                return CodeAddress::InstrInFunction {
+                    instr_id: self.instrument_address_convert_table[id].1,
+                }
+            }
+            Err(id) => {
+                if id < self.instrument_address_convert_table.len()
+                    && self.instrument_address_convert_table[id].0 - 1 == address
+                {
+                    return CodeAddress::InstrEdge {
+                        instr_id: self.instrument_address_convert_table[id].1,
+                    };
+                }
+            }
+        };
+
+        // If the address is not mapped to any instruction, falling back to function-range-based comparison.
+        let inclusive_range_comparor = |range: &(wasmparser::Range, Id<Function>)| {
+            // range.start < address <= range.end
+            if range.0.end < address {
+                Ordering::Less
+            } else if address <= range.0.start {
+                Ordering::Greater
+            } else {
+                Ordering::Equal
+            }
+        };
+        let exclusive_range_comparor = |range: &(wasmparser::Range, Id<Function>)| {
+            // normal comparison: range.start <= address < range.end
+            if range.0.end <= address {
+                Ordering::Less
+            } else if address < range.0.start {
+                Ordering::Greater
+            } else {
+                Ordering::Equal
+            }
+        };
+        let range_comparor: &dyn Fn(_) -> Ordering = match search_preference {
+            AddressSearchPreference::InclusiveFunctionEnd => &inclusive_range_comparor,
+            AddressSearchPreference::ExclusiveFunctionEnd => &exclusive_range_comparor,
+        };
+
+        match self.address_convert_table.binary_search_by(range_comparor) {
+            Ok(i) => {
+                let entry = &self.address_convert_table[i];
+                let code_offset_from_function_start = address - entry.0.start;
+
+                if address == entry.0.end {
+                    CodeAddress::FunctionEdge { id: entry.1 }
+                } else {
+                    CodeAddress::OffsetInFunction {
+                        id: entry.1,
+                        offset: code_offset_from_function_start,
+                    }
+                }
+            }
+            Err(_) => CodeAddress::Unknown,
+        }
+    }
+}
+
+/// Converts CodeAddress to translated code address
+pub(crate) struct CodeAddressConverter<'a> {
+    code_transform: &'a CodeTransform,
+}
+
+impl<'a> CodeAddressConverter<'a> {
+    pub(crate) fn new(code_transform: &'a CodeTransform) -> Self {
+        Self { code_transform }
+    }
+
+    pub(crate) fn find_address(&self, code: CodeAddress) -> Option<usize> {
+        match code {
+            CodeAddress::InstrInFunction { instr_id } => {
+                match self
+                    .code_transform
+                    .instruction_map
+                    .binary_search_by_key(&instr_id, |i| i.0)
+                {
+                    Ok(id) => Some(self.code_transform.instruction_map[id].1),
+                    Err(_) => None,
+                }
+            }
+            CodeAddress::InstrEdge { instr_id } => {
+                match self
+                    .code_transform
+                    .instruction_map
+                    .binary_search_by_key(&instr_id, |i| i.0)
+                {
+                    Ok(id) => Some(self.code_transform.instruction_map[id].1 - 1),
+                    Err(_) => None,
+                }
+            }
+            CodeAddress::OffsetInFunction { id, offset } => {
+                match self
+                    .code_transform
+                    .function_ranges
+                    .binary_search_by_key(&id, |i| i.0)
+                {
+                    Ok(id) => Some(self.code_transform.function_ranges[id].1.start + offset),
+                    Err(_) => None,
+                }
+            }
+            CodeAddress::FunctionEdge { id } => {
+                match self
+                    .code_transform
+                    .function_ranges
+                    .binary_search_by_key(&id, |i| i.0)
+                {
+                    Ok(id) => Some(self.code_transform.function_ranges[id].1.end),
+                    Err(_) => None,
+                }
+            }
+            CodeAddress::Unknown => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_code_address_generator() {
+        let mut module = crate::Module::default();
+
+        let mut func1 = crate::LocalFunction::new(
+            Vec::new(),
+            crate::FunctionBuilder::new(&mut module.types, &[], &[]),
+        );
+
+        func1.original_range = Some(wasmparser::Range { start: 20, end: 30 });
+
+        let id1 = module.funcs.add_local(func1);
+
+        let mut func2 = crate::LocalFunction::new(
+            Vec::new(),
+            crate::FunctionBuilder::new(&mut module.types, &[], &[]),
+        );
+
+        func2.original_range = Some(wasmparser::Range { start: 30, end: 50 });
+
+        let id2 = module.funcs.add_local(func2);
+
+        let address_converter = CodeAddressGenerator::new(&module.funcs);
+
+        assert_eq!(
+            address_converter.find_address(10, AddressSearchPreference::InclusiveFunctionEnd),
+            CodeAddress::Unknown
+        );
+        assert_eq!(
+            address_converter.find_address(20, AddressSearchPreference::ExclusiveFunctionEnd),
+            CodeAddress::OffsetInFunction { id: id1, offset: 0 }
+        );
+        assert_eq!(
+            address_converter.find_address(20, AddressSearchPreference::InclusiveFunctionEnd),
+            CodeAddress::Unknown
+        );
+        assert_eq!(
+            address_converter.find_address(25, AddressSearchPreference::ExclusiveFunctionEnd),
+            CodeAddress::OffsetInFunction { id: id1, offset: 5 }
+        );
+        assert_eq!(
+            address_converter.find_address(29, AddressSearchPreference::ExclusiveFunctionEnd),
+            CodeAddress::OffsetInFunction { id: id1, offset: 9 }
+        );
+        assert_eq!(
+            address_converter.find_address(29, AddressSearchPreference::InclusiveFunctionEnd),
+            CodeAddress::OffsetInFunction { id: id1, offset: 9 }
+        );
+        assert_eq!(
+            address_converter.find_address(30, AddressSearchPreference::InclusiveFunctionEnd),
+            CodeAddress::FunctionEdge { id: id1 }
+        );
+        assert_eq!(
+            address_converter.find_address(30, AddressSearchPreference::ExclusiveFunctionEnd),
+            CodeAddress::OffsetInFunction { id: id2, offset: 0 }
+        );
+        assert_eq!(
+            address_converter.find_address(50, AddressSearchPreference::InclusiveFunctionEnd),
+            CodeAddress::FunctionEdge { id: id2 }
+        );
+        assert_eq!(
+            address_converter.find_address(50, AddressSearchPreference::ExclusiveFunctionEnd),
+            CodeAddress::Unknown
+        );
+    }
+
+    #[test]
+    fn test_code_address_converter() {
+        let mut module = crate::Module::default();
+
+        let func1 = crate::LocalFunction::new(
+            Vec::new(),
+            crate::FunctionBuilder::new(&mut module.types, &[], &[]),
+        );
+        let id1 = module.funcs.add_local(func1);
+        let instr_id1 = InstrLocId::new(1);
+        let instr_id2 = InstrLocId::new(2);
+
+        let mut code_transform = CodeTransform::default();
+        {
+            code_transform
+                .function_ranges
+                .push((id1, wasmparser::Range { start: 50, end: 80 }));
+            code_transform.instruction_map.push((instr_id1, 60));
+            code_transform.instruction_map.push((instr_id2, 65));
+        }
+
+        let converter = CodeAddressConverter::new(&code_transform);
+
+        assert_eq!(
+            converter.find_address(CodeAddress::OffsetInFunction { id: id1, offset: 5 }),
+            Some(55)
+        );
+        assert_eq!(
+            converter.find_address(CodeAddress::InstrInFunction {
+                instr_id: instr_id1
+            }),
+            Some(60)
+        );
+        assert_eq!(
+            converter.find_address(CodeAddress::InstrEdge {
+                instr_id: instr_id2
+            }),
+            Some(64)
+        );
+        assert_eq!(
+            converter.find_address(CodeAddress::InstrInFunction {
+                instr_id: instr_id2
+            }),
+            Some(65)
+        );
+        assert_eq!(
+            converter.find_address(CodeAddress::FunctionEdge { id: id1 }),
+            Some(80)
+        );
+        assert_eq!(converter.find_address(CodeAddress::Unknown), None);
+    }
+}

--- a/src/module/debug/mod.rs
+++ b/src/module/debug/mod.rs
@@ -1,13 +1,13 @@
 mod dwarf;
+mod expression;
 mod units;
 
 use crate::emit::{Emit, EmitContext};
-use crate::{CustomSection, Function, InstrLocId, Module, ModuleFunctions, RawCustomSection};
+use crate::{CustomSection, Module, RawCustomSection};
 use gimli::*;
-use id_arena::Id;
-use std::cmp::Ordering;
 
 use self::dwarf::{AddressSearchPreference, ConvertContext, DEAD_CODE};
+use self::expression::{CodeAddressConverter, CodeAddressGenerator};
 use self::units::DebuggingInformationCursor;
 
 /// The DWARF debug section in input WebAssembly binary.
@@ -15,122 +15,6 @@ use self::units::DebuggingInformationCursor;
 pub struct ModuleDebugData {
     /// DWARF debug data
     pub dwarf: read::Dwarf<Vec<u8>>,
-}
-
-/// Specify roles of origial address.
-
-#[derive(Debug, PartialEq)]
-enum CodeAddress {
-    /// The address is instruction within a function.
-    InstrInFunction { instr_id: InstrLocId },
-    /// The address is one byte before the instruction.
-    InstrEdge { instr_id: InstrLocId },
-    /// The address is within a function, but does not match any instruction.
-    OffsetInFunction { id: Id<Function>, offset: usize },
-    /// The address is boundary of functions. Equals to OffsetInFunction with offset(section size).
-    FunctionEdge { id: Id<Function> },
-    /// The address is unknown.
-    Unknown,
-}
-
-/// Converts original code address to CodeAddress
-struct CodeAddressConverter {
-    /// Function range based convert table
-    address_convert_table: Vec<(wasmparser::Range, Id<Function>)>,
-    /// Instrument based convert table
-    instrument_address_convert_table: Vec<(usize, InstrLocId)>,
-}
-
-impl CodeAddressConverter {
-    fn from_emit_context(funcs: &ModuleFunctions) -> Self {
-        let mut address_convert_table = funcs
-            .iter_local()
-            .filter_map(|(func_id, func)| func.original_range.map(|range| (range, func_id)))
-            .collect::<Vec<_>>();
-
-        let mut instrument_address_convert_table = funcs
-            .iter_local()
-            .flat_map(|(_, func)| &func.instruction_mapping)
-            .copied()
-            .collect::<Vec<_>>();
-
-        address_convert_table.sort_by_key(|i| i.0.start);
-        instrument_address_convert_table.sort_by_key(|i| i.0);
-
-        Self {
-            address_convert_table,
-            instrument_address_convert_table,
-        }
-    }
-
-    fn find_address(
-        &self,
-        address: usize,
-        search_preference: AddressSearchPreference,
-    ) -> CodeAddress {
-        match self
-            .instrument_address_convert_table
-            .binary_search_by_key(&address, |i| i.0)
-        {
-            Ok(id) => {
-                return CodeAddress::InstrInFunction {
-                    instr_id: self.instrument_address_convert_table[id].1,
-                }
-            }
-            Err(id) => {
-                if id < self.instrument_address_convert_table.len()
-                    && self.instrument_address_convert_table[id].0 - 1 == address
-                {
-                    return CodeAddress::InstrEdge {
-                        instr_id: self.instrument_address_convert_table[id].1,
-                    };
-                }
-            }
-        };
-
-        // If the address is not mapped to any instruction, falling back to function-range-based comparison.
-        let inclusive_range_comparor = |range: &(wasmparser::Range, Id<Function>)| {
-            // range.start < address <= range.end
-            if range.0.end < address {
-                Ordering::Less
-            } else if address <= range.0.start {
-                Ordering::Greater
-            } else {
-                Ordering::Equal
-            }
-        };
-        let exclusive_range_comparor = |range: &(wasmparser::Range, Id<Function>)| {
-            // normal comparison: range.start <= address < range.end
-            if range.0.end <= address {
-                Ordering::Less
-            } else if address < range.0.start {
-                Ordering::Greater
-            } else {
-                Ordering::Equal
-            }
-        };
-        let range_comparor: &dyn Fn(_) -> Ordering = match search_preference {
-            AddressSearchPreference::InclusiveFunctionEnd => &inclusive_range_comparor,
-            AddressSearchPreference::ExclusiveFunctionEnd => &exclusive_range_comparor,
-        };
-
-        match self.address_convert_table.binary_search_by(range_comparor) {
-            Ok(i) => {
-                let entry = &self.address_convert_table[i];
-                let code_offset_from_function_start = address - entry.0.start;
-
-                if address == entry.0.end {
-                    CodeAddress::FunctionEdge { id: entry.1 }
-                } else {
-                    CodeAddress::OffsetInFunction {
-                        id: entry.1,
-                        offset: code_offset_from_function_start,
-                    }
-                }
-            }
-            Err(_) => CodeAddress::Unknown,
-        }
-    }
 }
 
 impl Module {
@@ -158,46 +42,13 @@ impl Module {
 
 impl Emit for ModuleDebugData {
     fn emit(&self, cx: &mut EmitContext) {
-        let address_converter = CodeAddressConverter::from_emit_context(&cx.module.funcs);
-
-        let code_transform = &cx.code_transform;
-        let instruction_map = &code_transform.instruction_map;
+        let address_generator = CodeAddressGenerator::new(&cx.module.funcs);
+        let address_converter = CodeAddressConverter::new(&cx.code_transform);
 
         let convert_address = |address, search_preference| -> Option<write::Address> {
             let address = address as usize;
-            let address = match address_converter.find_address(address, search_preference) {
-                CodeAddress::InstrInFunction { instr_id } => {
-                    match instruction_map.binary_search_by_key(&instr_id, |i| i.0) {
-                        Ok(id) => Some(instruction_map[id].1),
-                        Err(_) => None,
-                    }
-                }
-                CodeAddress::InstrEdge { instr_id } => {
-                    match instruction_map.binary_search_by_key(&instr_id, |i| i.0) {
-                        Ok(id) => Some(instruction_map[id].1 - 1),
-                        Err(_) => None,
-                    }
-                }
-                CodeAddress::OffsetInFunction { id, offset } => {
-                    match code_transform
-                        .function_ranges
-                        .binary_search_by_key(&id, |i| i.0)
-                    {
-                        Ok(id) => Some(code_transform.function_ranges[id].1.start + offset),
-                        Err(_) => None,
-                    }
-                }
-                CodeAddress::FunctionEdge { id } => {
-                    match code_transform
-                        .function_ranges
-                        .binary_search_by_key(&id, |i| i.0)
-                    {
-                        Ok(id) => Some(code_transform.function_ranges[id].1.end),
-                        Err(_) => None,
-                    }
-                }
-                CodeAddress::Unknown => None,
-            };
+            let code = address_generator.find_address(address, search_preference);
+            let address = address_converter.find_address(code);
 
             address
                 .map(|x| (x - cx.code_transform.code_section_start) as u64)
@@ -212,10 +63,11 @@ impl Emit for ModuleDebugData {
 
         let mut dwarf = write::Dwarf::from(&from_dwarf, &|address| {
             if address == 0 || address == DEAD_CODE {
-                return Some(write::Address::Constant(address));
+                Some(write::Address::Constant(address))
+            } else {
+                convert_address(address, AddressSearchPreference::InclusiveFunctionEnd)
+                    .or(Some(write::Address::Constant(DEAD_CODE)))
             }
-            convert_address(address, AddressSearchPreference::InclusiveFunctionEnd)
-                .or(Some(write::Address::Constant(DEAD_CODE)))
         })
         .expect("cannot convert to writable dwarf");
 
@@ -268,70 +120,4 @@ impl Emit for ModuleDebugData {
             )
             .expect("never");
     }
-}
-
-#[test]
-fn dwarf_address_converter() {
-    let mut module = crate::Module::default();
-
-    let mut func1 = crate::LocalFunction::new(
-        Vec::new(),
-        crate::FunctionBuilder::new(&mut module.types, &[], &[]),
-    );
-
-    func1.original_range = Some(wasmparser::Range { start: 20, end: 30 });
-
-    let id1 = module.funcs.add_local(func1);
-
-    let mut func2 = crate::LocalFunction::new(
-        Vec::new(),
-        crate::FunctionBuilder::new(&mut module.types, &[], &[]),
-    );
-
-    func2.original_range = Some(wasmparser::Range { start: 30, end: 50 });
-
-    let id2 = module.funcs.add_local(func2);
-
-    let address_converter = CodeAddressConverter::from_emit_context(&module.funcs);
-
-    assert_eq!(
-        address_converter.find_address(10, AddressSearchPreference::InclusiveFunctionEnd),
-        CodeAddress::Unknown
-    );
-    assert_eq!(
-        address_converter.find_address(20, AddressSearchPreference::ExclusiveFunctionEnd),
-        CodeAddress::OffsetInFunction { id: id1, offset: 0 }
-    );
-    assert_eq!(
-        address_converter.find_address(20, AddressSearchPreference::InclusiveFunctionEnd),
-        CodeAddress::Unknown
-    );
-    assert_eq!(
-        address_converter.find_address(25, AddressSearchPreference::ExclusiveFunctionEnd),
-        CodeAddress::OffsetInFunction { id: id1, offset: 5 }
-    );
-    assert_eq!(
-        address_converter.find_address(29, AddressSearchPreference::ExclusiveFunctionEnd),
-        CodeAddress::OffsetInFunction { id: id1, offset: 9 }
-    );
-    assert_eq!(
-        address_converter.find_address(29, AddressSearchPreference::InclusiveFunctionEnd),
-        CodeAddress::OffsetInFunction { id: id1, offset: 9 }
-    );
-    assert_eq!(
-        address_converter.find_address(30, AddressSearchPreference::InclusiveFunctionEnd),
-        CodeAddress::FunctionEdge { id: id1 }
-    );
-    assert_eq!(
-        address_converter.find_address(30, AddressSearchPreference::ExclusiveFunctionEnd),
-        CodeAddress::OffsetInFunction { id: id2, offset: 0 }
-    );
-    assert_eq!(
-        address_converter.find_address(50, AddressSearchPreference::InclusiveFunctionEnd),
-        CodeAddress::FunctionEdge { id: id2 }
-    );
-    assert_eq!(
-        address_converter.find_address(50, AddressSearchPreference::ExclusiveFunctionEnd),
-        CodeAddress::Unknown
-    );
 }

--- a/src/module/debug/mod.rs
+++ b/src/module/debug/mod.rs
@@ -50,8 +50,7 @@ impl CodeAddressConverter {
 
         let mut instrument_address_convert_table = funcs
             .iter_local()
-            .map(|(_, func)| &func.instruction_mapping)
-            .flatten()
+            .flat_map(|(_, func)| &func.instruction_mapping)
             .copied()
             .collect::<Vec<_>>();
 

--- a/src/module/debug/mod.rs
+++ b/src/module/debug/mod.rs
@@ -210,8 +210,11 @@ impl Emit for ModuleDebugData {
             .borrow(|sections| EndianSlice::new(sections.as_ref(), LittleEndian));
 
         let mut dwarf = write::Dwarf::from(&from_dwarf, &|address| {
+            if address == 0 || address == DEAD_CODE {
+                return Some(write::Address::Constant(address));
+            }
             convert_address(address, AddressSearchPreference::InclusiveFunctionEnd)
-                .or(Some(write::Address::Constant(0)))
+                .or(Some(write::Address::Constant(DEAD_CODE)))
         })
         .expect("cannot convert to writable dwarf");
 

--- a/src/module/debug/units.rs
+++ b/src/module/debug/units.rs
@@ -18,7 +18,7 @@ impl<'a> DebuggingInformationCursor<'a> {
     }
 
     pub fn current(&mut self) -> Option<&mut DebuggingInformationEntry> {
-        if self.entry_id_stack.len() > 0 {
+        if !self.entry_id_stack.is_empty() {
             Some(self.unit.get_mut(*self.entry_id_stack.last().unwrap()))
         } else {
             None
@@ -30,10 +30,10 @@ impl<'a> DebuggingInformationCursor<'a> {
             let root = self.unit.root();
             self.entry_id_stack.push(root);
             self.called_next_dfs = true;
-            return None;
+            return self.current();
         }
 
-        if self.entry_id_stack.len() == 0 {
+        if self.entry_id_stack.is_empty() {
             return None;
         }
 

--- a/src/module/debug/units.rs
+++ b/src/module/debug/units.rs
@@ -1,0 +1,53 @@
+use gimli::write::{DebuggingInformationEntry, Unit, UnitEntryId};
+
+pub(crate) struct DebuggingInformationCursor<'a> {
+    entry_id_stack: Vec<UnitEntryId>,
+
+    unit: &'a mut Unit,
+
+    called_next_dfs: bool,
+}
+
+impl<'a> DebuggingInformationCursor<'a> {
+    pub fn new(unit: &'a mut Unit) -> Self {
+        Self {
+            unit,
+            entry_id_stack: Vec::new(),
+            called_next_dfs: false,
+        }
+    }
+
+    pub fn current(&mut self) -> Option<&mut DebuggingInformationEntry> {
+        if self.entry_id_stack.len() > 0 {
+            Some(self.unit.get_mut(*self.entry_id_stack.last().unwrap()))
+        } else {
+            None
+        }
+    }
+
+    pub fn next_dfs(&mut self) -> Option<&mut DebuggingInformationEntry> {
+        if !self.called_next_dfs {
+            let root = self.unit.root();
+            self.entry_id_stack.push(root);
+            self.called_next_dfs = true;
+            return None;
+        }
+
+        if self.entry_id_stack.len() == 0 {
+            return None;
+        }
+
+        let last_element_id = self.entry_id_stack.pop().unwrap();
+        let last_element = self.unit.get_mut(last_element_id);
+
+        self.entry_id_stack.append(
+            &mut last_element
+                .children()
+                .map(UnitEntryId::clone)
+                .rev()
+                .collect(),
+        );
+
+        self.current()
+    }
+}

--- a/src/module/functions/local_function/context.rs
+++ b/src/module/functions/local_function/context.rs
@@ -54,6 +54,7 @@ pub(crate) struct ValidationContext<'a> {
 
 #[derive(Debug)]
 pub struct IfElseState {
+    pub start: InstrLocId,
     pub consequent: InstrSeqId,
     pub alternative: Option<InstrSeqId>,
 }

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -84,6 +84,12 @@ impl<'instr> Visitor<'instr> for Emit<'_> {
 
         debug_assert_eq!(self.blocks.len(), self.block_kinds.len());
 
+        if let Some(map) = self.map.as_mut() {
+            let pos = self.encoder.byte_len();
+            // Save the encoded_at position for the specified ExprId.
+            map.push((seq.end.clone(), pos));
+        }
+
         if let BlockKind::If = popped_kind.unwrap() {
             // We're about to visit the `else` block, so push its kind.
             //

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -330,7 +330,7 @@ impl Module {
 
         let indices = &mut IdsToIndices::default();
 
-        let mut customs = mem::replace(&mut self.customs, ModuleCustomSections::default());
+        let mut customs = mem::take(&mut self.customs);
 
         let mut cx = EmitContext {
             module: self,
@@ -386,7 +386,7 @@ impl Module {
 
             cx.wasm_module.section(&wasm_encoder::CustomSection {
                 name: section.name().into(),
-                data: section.data(&indices).into(),
+                data: section.data(&indices),
             });
         }
 


### PR DESCRIPTION
This PR contains following changes:

- high_pc attribute value in .debug_abbrev section
- perform code transformation of `else` and `end` instructions

With this PR, almost all instructions except for instructions in stripped function are converted.