### PR TITLE
chore: update `wasm-encoder` dependency to 0.38.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ leb128 = "0.2.4"
 log = "0.4.8"
 rayon = { version = "1.1.0", optional = true }
 walrus-macro = { path = './crates/macro', version = '=0.19.0' }
-wasm-encoder = "0.29.0"
+wasm-encoder = "0.38.1"
 wasmparser = "0.80.2"
 gimli = "0.26.0"
 

--- a/src/module/elements.rs
+++ b/src/module/elements.rs
@@ -185,7 +185,10 @@ impl Emit for ModuleElements {
                         None => wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::Func),
                     })
                     .collect();
-                let els = wasm_encoder::Elements::Expressions(els_vec.as_slice());
+                let els = wasm_encoder::Elements::Expressions(
+                    wasm_encoder::RefType::FUNCREF,
+                    els_vec.as_slice(),
+                );
                 emit_elem(cx, &mut wasm_element_section, &element.kind, els);
             } else {
                 let els_vec: Vec<u32> = element
@@ -212,15 +215,14 @@ impl Emit for ModuleElements {
                         wasm_element_section.active(
                             table_index,
                             &offset.to_wasmencoder_type(&cx),
-                            wasm_encoder::RefType::FUNCREF,
                             els,
                         );
                     }
                     ElementKind::Passive => {
-                        wasm_element_section.passive(wasm_encoder::RefType::FUNCREF, els);
+                        wasm_element_section.passive(els);
                     }
                     ElementKind::Declared => {
-                        wasm_element_section.declared(wasm_encoder::RefType::FUNCREF, els);
+                        wasm_element_section.declared(els);
                     }
                 }
             }


### PR DESCRIPTION
In our [clarity-wasm](https://github.com/stacks-network/clarity-wasm) work, I was running into some issues with this older version. There was just one code change needed and I think it is pretty straight-forward. Thanks!