### PR TITLE
Allow merging modules and skipping DWARF reading on load

### DIFF
--- a/src/module/config.rs
+++ b/src/module/config.rs
@@ -208,6 +208,12 @@ impl ModuleConfig {
         Module::parse(wasm, self)
     }
 
+    /// Parses an in-memory WebAssembly file into an existing `Module` using this
+    /// configuration.
+    pub fn parse_into(&self, wasm: &[u8], pre: &mut Module) -> Result<()> {
+        Module::parse_in(wasm, self, pre)
+    }
+
     /// Parses a WebAssembly file into a `Module` using this configuration.
     pub fn parse_file<P>(&self, path: P) -> Result<Module>
     where

--- a/src/module/config.rs
+++ b/src/module/config.rs
@@ -18,6 +18,7 @@ pub struct ModuleConfig {
     pub(crate) on_parse:
         Option<Box<dyn Fn(&mut Module, &IndicesToIds) -> Result<()> + Sync + Send + 'static>>,
     pub(crate) on_instr_loc: Option<Box<dyn Fn(&usize) -> InstrLocId + Sync + Send + 'static>>,
+    pub(crate) no_read_dwarf: bool,
 }
 
 impl Clone for ModuleConfig {
@@ -32,6 +33,7 @@ impl Clone for ModuleConfig {
             skip_producers_section: self.skip_producers_section,
             skip_name_section: self.skip_name_section,
             preserve_code_transform: self.preserve_code_transform,
+            no_read_dwarf: self.no_read_dwarf,
 
             // ... and this is left empty.
             on_parse: None,
@@ -54,6 +56,7 @@ impl fmt::Debug for ModuleConfig {
             ref preserve_code_transform,
             ref on_parse,
             ref on_instr_loc,
+            ref no_read_dwarf,
         } = self;
 
         f.debug_struct("ModuleConfig")
@@ -69,6 +72,7 @@ impl fmt::Debug for ModuleConfig {
             .field("preserve_code_transform", preserve_code_transform)
             .field("on_parse", &on_parse.as_ref().map(|_| ".."))
             .field("on_instr_loc", &on_instr_loc.as_ref().map(|_| ".."))
+            .field("no_read_dwarf", no_read_dwarf)
             .finish()
     }
 }
@@ -79,6 +83,11 @@ impl ModuleConfig {
         ModuleConfig::default()
     }
 
+    /// Sets a flag to whether DWARF debug sections are read for this module.
+    pub fn read_dwarf(&mut self, dw: bool) -> &mut ModuleConfig{
+        self.no_read_dwarf = !dw;
+        return self;
+    }
     /// Sets a flag to whether DWARF debug sections are generated for this
     /// module.
     ///

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -129,7 +129,7 @@ impl Module {
     }
 
     /// Merge a module from the in-memory wasm buffer with the default configuration
-    pub fn merge_buffer(&mut self, wasm: &[u8]) -> Result<()>{
+    pub fn merge_buffer(&mut self, wasm: &[u8]) -> Result<()> {
         return Self::parse_in(wasm, &ModuleConfig::default(), self);
     }
 

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -128,9 +128,20 @@ impl Module {
         ModuleConfig::new().parse(wasm)
     }
 
+    /// Merge a module from the in-memory wasm buffer with the default configuration
+    pub fn merge_buffer(&mut self, wasm: &[u8]) -> Result<()>{
+        return Self::parse_in(wasm, &ModuleConfig::default(), self);
+    }
+
     fn parse(wasm: &[u8], config: &ModuleConfig) -> Result<Module> {
         let mut ret = Module::default();
         ret.config = config.clone();
+        Self::parse_in(wasm, config, &mut ret)?;
+        return Ok(ret);
+    }
+    fn parse_in(wasm: &[u8], config: &ModuleConfig, ret: &mut Module) -> Result<()> {
+        // let mut ret = Module::default();
+        // ret.config = config.clone();
         let mut indices = IndicesToIds::default();
         let mut validator = Validator::new();
         validator.wasm_features(WasmFeatures {
@@ -307,11 +318,11 @@ impl Module {
             .add_processed_by("walrus", env!("CARGO_PKG_VERSION"));
 
         if let Some(on_parse) = &config.on_parse {
-            on_parse(&mut ret, &indices)?;
+            on_parse(ret, &indices)?;
         }
 
         log::debug!("parse complete");
-        Ok(ret)
+        Ok(())
     }
 
     /// Emit this module into a `.wasm` file at the given path.


### PR DESCRIPTION
I added this because, as far as I know, no other Rust WASM library can easily do this. I also need this for a project.