### PR TITLE
Fix wording in documentation

### DIFF
--- a/src/module/globals.rs
+++ b/src/module/globals.rs
@@ -73,12 +73,12 @@ impl ModuleGlobals {
         })
     }
 
-    /// Gets a reference to a memory given its id
+    /// Gets a reference to a global given its id
     pub fn get(&self, id: GlobalId) -> &Global {
         &self.arena[id]
     }
 
-    /// Gets a reference to a memory given its id
+    /// Gets a reference to a global given its id
     pub fn get_mut(&mut self, id: GlobalId) -> &mut Global {
         &mut self.arena[id]
     }

--- a/src/module/locals.rs
+++ b/src/module/locals.rs
@@ -20,17 +20,17 @@ impl ModuleLocals {
         id
     }
 
-    /// Get the local for an ID
+    /// Gets a reference to a local given its id
     pub fn get(&self, id: LocalId) -> &Local {
         &self.arena[id]
     }
 
-    /// Get the set of locals for this module.
+    /// Gets a reference to a local given its id
     pub fn get_mut(&mut self, id: LocalId) -> &mut Local {
         &mut self.arena[id]
     }
 
-    /// Get a shared reference to this module's globals.
+    /// Get a shared reference to this module's locals.
     pub fn iter(&self) -> impl Iterator<Item = &Local> {
         self.arena.iter().map(|(_, f)| f)
     }


### PR DESCRIPTION
Fixes some errors in the docs.

Also changed the wording in `locals.rs` to improve its consistency with the wording in the corresponding function docs in `globals.rs` and `memories.rs`.