### PR TITLE
GC private tables

### DIFF
--- a/crates/tests/tests/spec-tests.rs
+++ b/crates/tests/tests/spec-tests.rs
@@ -159,8 +159,10 @@ fn run(wast: &Path) -> Result<(), anyhow::Error> {
         // Tests which assert that they're not linkable tend to not work with
         // the gc pass because it removes things which would cause a module to
         // become unlinkable. This doesn't matter too much in the real world
-        // (hopefully), so just don't gc assert_unlinkable modules.
-        if cmd != "assert_unlinkable" {
+        // (hopefully), so just don't gc assert_unlinkable modules. The same
+        // applies to assert_uninstantiable modules due to removal of unused
+        // elements and tables.
+        if !matches!(cmd.as_str(), "assert_unlinkable" | "assert_uninstantiable") {
             walrus::passes::gc::run(&mut module);
         }
 

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -130,15 +130,14 @@ impl Used {
         for elem in module.elements.iter() {
             match elem.kind {
                 // Active segments are rooted because they initialize imported
-                // or exported tables. Declared segments can probably get gc'd
-                // but for now we're conservative and we root them.
+                // tables.
                 ElementKind::Active { table, .. } => {
-                    if module.exports.get_exported_table(table).is_some()
-                        || module.tables.get(table).import.is_some()
-                    {
+                    if module.tables.get(table).import.is_some() {
                         stack.push_element(elem.id());
                     }
                 }
+                // Declared segments can probably get gc'd but for now we're
+                // conservative and we root them
                 ElementKind::Declared => {
                     stack.push_element(elem.id());
                 }

--- a/src/passes/used.rs
+++ b/src/passes/used.rs
@@ -132,7 +132,14 @@ impl Used {
                 // Active segments are rooted because they initialize imported
                 // or exported tables. Declared segments can probably get gc'd
                 // but for now we're conservative and we root them.
-                ElementKind::Active { .. } | ElementKind::Declared => {
+                ElementKind::Active { table, .. } => {
+                    if module.exports.get_exported_table(table).is_some()
+                        || module.tables.get(table).import.is_some()
+                    {
+                        stack.push_element(elem.id());
+                    }
+                }
+                ElementKind::Declared => {
                     stack.push_element(elem.id());
                 }
                 ElementKind::Passive => {}


### PR DESCRIPTION
GC now does not consider elem to private tables to be used.

So in practice this branch allowed me to strip out dynamic dispatched functions (rust's `std::fmt`) after using wizer on a module.