### PR TITLE
fix: add non_exhaustive to Instr enum

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -249,6 +249,7 @@ pub(crate) enum BlockKind {
 /// ```
 #[walrus_instr]
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum Instr {
     /// `block ... end`
     #[walrus(skip_builder)]


### PR DESCRIPTION
Resolves https://github.com/rustwasm/walrus/issues/274 in making the new `Instr` options for tail calls non exhaustivec.