### PR TITLE
feat: remove non_exhaustive from Instr enum

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -249,7 +249,6 @@ pub(crate) enum BlockKind {
 /// ```
 #[walrus_instr]
 #[derive(Clone, Debug)]
-#[non_exhaustive]
 pub enum Instr {
     /// `block ... end`
     #[walrus(skip_builder)]


### PR DESCRIPTION
Removes the `non_exhaustive` from the `Instr` enum for the next semver major release.