### PR TITLE
Specify "shared" attribute of TableType to enable upgrade of wasm encoder to 0.213

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ leb128 = "0.2.4"
 log = "0.4.8"
 rayon = { version = "1.1.0", optional = true }
 walrus-macro = { path = './crates/macro', version = '=0.22.0' }
-wasm-encoder = "0.212.0"
-wasmparser = "0.212.0"
+wasm-encoder = "0.213.0"
+wasmparser = "0.213.0"
 gimli = "0.26.0"
 
 [features]

--- a/src/module/imports.rs
+++ b/src/module/imports.rs
@@ -301,6 +301,7 @@ impl Emit for ModuleImports {
                             table64: table.table64,
                             minimum: table.initial,
                             maximum: table.maximum,
+                            shared: false,
                         })
                     }
                     ImportKind::Memory(id) => {

--- a/src/module/tables.rs
+++ b/src/module/tables.rs
@@ -192,6 +192,7 @@ impl Emit for ModuleTables {
                     RefType::Externref => wasm_encoder::RefType::EXTERNREF,
                     RefType::Funcref => wasm_encoder::RefType::FUNCREF,
                 },
+                shared: false,
             });
         }
 


### PR DESCRIPTION
wasm-encoder has a struct TableType which got a new attribute "shared".

The context is a proposal to share data among threads.

We set the attribute to false which means that the table is not to be shared.
This is the defensive setting and seems closest to status quo / ignoring the proposal.

In other words, this change only makes walrus compile with more recent versions and is not an attempt to do anything smart about the shared-everything-threads proposal.