### PR TITLE
Enable relaxed SIMD by default

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -605,6 +605,13 @@ pub enum Instr {
         /// The table which `func` below is indexing into
         table: TableId,
     },
+
+    /// Various relaxed SIMD instructions.
+    RelaxedSimd {
+        /// The relaxed SIMD operation being performed
+        #[walrus(skip_visit)]
+        op: RelaxedSimdOp,
+    },
 }
 
 /// Argument in `V128Shuffle` of lane indices to select
@@ -875,6 +882,14 @@ pub enum BinaryOp {
     I64x2ExtMulHighI32x4S,
     I64x2ExtMulLowI32x4U,
     I64x2ExtMulHighI32x4U,
+
+    I8x16RelaxedSwizzle,
+    F32x4RelaxedMin,
+    F32x4RelaxedMax,
+    F64x2RelaxedMin,
+    F64x2RelaxedMax,
+    I16x8RelaxedQ15mulrS,
+    I16x8RelaxedDotI8x16I7x16S,
 }
 
 /// Possible unary operations in wasm
@@ -1029,6 +1044,11 @@ pub enum UnaryOp {
     I32x4WidenLowI16x8U,
     I32x4WidenHighI16x8S,
     I32x4WidenHighI16x8U,
+
+    I32x4RelaxedTruncF32x4S,
+    I32x4RelaxedTruncF32x4U,
+    I32x4RelaxedTruncF64x2SZero,
+    I32x4RelaxedTruncF64x2UZero,
 }
 
 /// The different kinds of load instructions that are part of a `Load` IR node
@@ -1220,6 +1240,21 @@ impl AtomicWidth {
     }
 }
 
+/// The different kinds of atomic rmw operations
+#[derive(Debug, Copy, Clone)]
+#[allow(missing_docs)]
+pub enum RelaxedSimdOp {
+    F32x4RelaxedMadd,
+    F32x4RelaxedNmadd,
+    F64x2RelaxedMadd,
+    F64x2RelaxedNmadd,
+    I8x16RelaxedLaneselect,
+    I16x8RelaxedLaneselect,
+    I32x4RelaxedLaneselect,
+    I64x2RelaxedLaneselect,
+    I32x4RelaxedDotI8x16I7x16AddS,
+}
+
 impl Instr {
     /// Are any instructions that follow this instruction's instruction (within
     /// the current block) unreachable?
@@ -1281,7 +1316,8 @@ impl Instr {
             | Instr::TableInit(..)
             | Instr::TableCopy(..)
             | Instr::ElemDrop(..)
-            | Instr::Drop(..) => false,
+            | Instr::Drop(..)
+            | Instr::RelaxedSimd(..) => false,
         }
     }
 }

--- a/src/module/config.rs
+++ b/src/module/config.rs
@@ -175,6 +175,7 @@ impl ModuleConfig {
         features.insert(WasmFeatures::REFERENCE_TYPES);
         features.insert(WasmFeatures::BULK_MEMORY);
         features.insert(WasmFeatures::SIMD);
+        features.insert(WasmFeatures::RELAXED_SIMD);
         features.insert(WasmFeatures::TAIL_CALL);
         // Enable supported active proposals.
         if !self.only_stable_features {

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -427,6 +427,14 @@ impl<'instr> Visitor<'instr> for Emit<'_> {
                     I64x2ExtMulHighI32x4S => Instruction::I64x2ExtMulHighI32x4S,
                     I64x2ExtMulLowI32x4U => Instruction::I64x2ExtMulLowI32x4U,
                     I64x2ExtMulHighI32x4U => Instruction::I64x2ExtMulHighI32x4U,
+
+                    I8x16RelaxedSwizzle => Instruction::I8x16RelaxedSwizzle,
+                    F32x4RelaxedMin => Instruction::F32x4RelaxedMin,
+                    F32x4RelaxedMax => Instruction::F32x4RelaxedMax,
+                    F64x2RelaxedMin => Instruction::F64x2RelaxedMin,
+                    F64x2RelaxedMax => Instruction::F64x2RelaxedMax,
+                    I16x8RelaxedQ15mulrS => Instruction::I16x8RelaxedQ15mulrS,
+                    I16x8RelaxedDotI8x16I7x16S => Instruction::I16x8RelaxedDotI8x16I7x16S,
                 }
             }
 
@@ -586,6 +594,11 @@ impl<'instr> Visitor<'instr> for Emit<'_> {
                     F64x2ConvertLowI32x4U => Instruction::F64x2ConvertLowI32x4U,
                     F32x4DemoteF64x2Zero => Instruction::F32x4DemoteF64x2Zero,
                     F64x2PromoteLowF32x4 => Instruction::F64x2PromoteLowF32x4,
+
+                    I32x4RelaxedTruncF32x4S => Instruction::I32x4RelaxedTruncF32x4S,
+                    I32x4RelaxedTruncF32x4U => Instruction::I32x4RelaxedTruncF32x4U,
+                    I32x4RelaxedTruncF64x2SZero => Instruction::I32x4RelaxedTruncF64x2SZero,
+                    I32x4RelaxedTruncF64x2UZero => Instruction::I32x4RelaxedTruncF64x2UZero,
                 }
             }
 
@@ -854,6 +867,19 @@ impl<'instr> Visitor<'instr> for Emit<'_> {
                     table_index,
                 }
             }
+            RelaxedSimd(e) => match e.op {
+                RelaxedSimdOp::F32x4RelaxedMadd => Instruction::F32x4RelaxedMadd,
+                RelaxedSimdOp::F32x4RelaxedNmadd => Instruction::F32x4RelaxedNmadd,
+                RelaxedSimdOp::F64x2RelaxedMadd => Instruction::F64x2RelaxedMadd,
+                RelaxedSimdOp::F64x2RelaxedNmadd => Instruction::F64x2RelaxedNmadd,
+                RelaxedSimdOp::I8x16RelaxedLaneselect => Instruction::I8x16RelaxedLaneselect,
+                RelaxedSimdOp::I16x8RelaxedLaneselect => Instruction::I16x8RelaxedLaneselect,
+                RelaxedSimdOp::I32x4RelaxedLaneselect => Instruction::I32x4RelaxedLaneselect,
+                RelaxedSimdOp::I64x2RelaxedLaneselect => Instruction::I64x2RelaxedLaneselect,
+                RelaxedSimdOp::I32x4RelaxedDotI8x16I7x16AddS => {
+                    Instruction::I32x4RelaxedDotI8x16I7x16AddS
+                }
+            },
         });
     }
 }

--- a/src/module/functions/local_function/emit.rs
+++ b/src/module/functions/local_function/emit.rs
@@ -187,6 +187,22 @@ impl<'instr> Visitor<'instr> for Emit<'_> {
                 Instruction::MemoryFill(idx)
             }
 
+            TernOp(e) => {
+                use crate::ir::TernaryOp::*;
+
+                match e.op {
+                    F32x4RelaxedMadd => Instruction::F32x4RelaxedMadd,
+                    F32x4RelaxedNmadd => Instruction::F32x4RelaxedNmadd,
+                    F64x2RelaxedMadd => Instruction::F64x2RelaxedMadd,
+                    F64x2RelaxedNmadd => Instruction::F64x2RelaxedNmadd,
+                    I8x16RelaxedLaneselect => Instruction::I8x16RelaxedLaneselect,
+                    I16x8RelaxedLaneselect => Instruction::I16x8RelaxedLaneselect,
+                    I32x4RelaxedLaneselect => Instruction::I32x4RelaxedLaneselect,
+                    I64x2RelaxedLaneselect => Instruction::I64x2RelaxedLaneselect,
+                    I32x4RelaxedDotI8x16I7x16AddS => Instruction::I32x4RelaxedDotI8x16I7x16AddS,
+                }
+            }
+
             Binop(e) => {
                 use crate::ir::BinaryOp::*;
 
@@ -867,19 +883,6 @@ impl<'instr> Visitor<'instr> for Emit<'_> {
                     table_index,
                 }
             }
-            RelaxedSimd(e) => match e.op {
-                RelaxedSimdOp::F32x4RelaxedMadd => Instruction::F32x4RelaxedMadd,
-                RelaxedSimdOp::F32x4RelaxedNmadd => Instruction::F32x4RelaxedNmadd,
-                RelaxedSimdOp::F64x2RelaxedMadd => Instruction::F64x2RelaxedMadd,
-                RelaxedSimdOp::F64x2RelaxedNmadd => Instruction::F64x2RelaxedNmadd,
-                RelaxedSimdOp::I8x16RelaxedLaneselect => Instruction::I8x16RelaxedLaneselect,
-                RelaxedSimdOp::I16x8RelaxedLaneselect => Instruction::I16x8RelaxedLaneselect,
-                RelaxedSimdOp::I32x4RelaxedLaneselect => Instruction::I32x4RelaxedLaneselect,
-                RelaxedSimdOp::I64x2RelaxedLaneselect => Instruction::I64x2RelaxedLaneselect,
-                RelaxedSimdOp::I32x4RelaxedDotI8x16I7x16AddS => {
-                    Instruction::I32x4RelaxedDotI8x16I7x16AddS
-                }
-            },
         });
     }
 }

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -317,6 +317,9 @@ fn append_instruction(ctx: &mut ValidationContext, inst: Operator, loc: InstrLoc
     let binop = |ctx: &mut ValidationContext, op| {
         ctx.alloc_instr(Binop { op }, loc);
     };
+    let ternop = |ctx: &mut ValidationContext, op| {
+        ctx.alloc_instr(TernOp { op }, loc);
+    };
 
     let mem_arg = |ctx: &mut ValidationContext, arg: &wasmparser::MemArg| -> (MemoryId, MemArg) {
         (
@@ -359,10 +362,6 @@ fn append_instruction(ctx: &mut ValidationContext, inst: Operator, loc: InstrLoc
     let load_simd = |ctx: &mut ValidationContext, arg, kind| {
         let (memory, arg) = mem_arg(ctx, &arg);
         ctx.alloc_instr(LoadSimd { memory, arg, kind }, loc);
-    };
-
-    let relaxed_simd = |ctx: &mut ValidationContext, op| {
-        ctx.alloc_instr(RelaxedSimd { op }, loc);
     };
     match inst {
         Operator::Call { function_index } => {
@@ -1339,22 +1338,14 @@ fn append_instruction(ctx: &mut ValidationContext, inst: Operator, loc: InstrLoc
         Operator::I32x4RelaxedTruncF32x4U => unop(ctx, UnaryOp::I32x4RelaxedTruncF32x4U),
         Operator::I32x4RelaxedTruncF64x2SZero => unop(ctx, UnaryOp::I32x4RelaxedTruncF64x2SZero),
         Operator::I32x4RelaxedTruncF64x2UZero => unop(ctx, UnaryOp::I32x4RelaxedTruncF64x2UZero),
-        Operator::F32x4RelaxedMadd => relaxed_simd(ctx, RelaxedSimdOp::F32x4RelaxedMadd),
-        Operator::F32x4RelaxedNmadd => relaxed_simd(ctx, RelaxedSimdOp::F32x4RelaxedNmadd),
-        Operator::F64x2RelaxedMadd => relaxed_simd(ctx, RelaxedSimdOp::F64x2RelaxedMadd),
-        Operator::F64x2RelaxedNmadd => relaxed_simd(ctx, RelaxedSimdOp::F64x2RelaxedNmadd),
-        Operator::I8x16RelaxedLaneselect => {
-            relaxed_simd(ctx, RelaxedSimdOp::I8x16RelaxedLaneselect)
-        }
-        Operator::I16x8RelaxedLaneselect => {
-            relaxed_simd(ctx, RelaxedSimdOp::I16x8RelaxedLaneselect)
-        }
-        Operator::I32x4RelaxedLaneselect => {
-            relaxed_simd(ctx, RelaxedSimdOp::I32x4RelaxedLaneselect)
-        }
-        Operator::I64x2RelaxedLaneselect => {
-            relaxed_simd(ctx, RelaxedSimdOp::I64x2RelaxedLaneselect)
-        }
+        Operator::F32x4RelaxedMadd => ternop(ctx, TernaryOp::F32x4RelaxedMadd),
+        Operator::F32x4RelaxedNmadd => ternop(ctx, TernaryOp::F32x4RelaxedNmadd),
+        Operator::F64x2RelaxedMadd => ternop(ctx, TernaryOp::F64x2RelaxedMadd),
+        Operator::F64x2RelaxedNmadd => ternop(ctx, TernaryOp::F64x2RelaxedNmadd),
+        Operator::I8x16RelaxedLaneselect => ternop(ctx, TernaryOp::I8x16RelaxedLaneselect),
+        Operator::I16x8RelaxedLaneselect => ternop(ctx, TernaryOp::I16x8RelaxedLaneselect),
+        Operator::I32x4RelaxedLaneselect => ternop(ctx, TernaryOp::I32x4RelaxedLaneselect),
+        Operator::I64x2RelaxedLaneselect => ternop(ctx, TernaryOp::I64x2RelaxedLaneselect),
         Operator::F32x4RelaxedMin => binop(ctx, BinaryOp::F32x4RelaxedMin),
         Operator::F32x4RelaxedMax => binop(ctx, BinaryOp::F32x4RelaxedMax),
         Operator::F64x2RelaxedMin => binop(ctx, BinaryOp::F64x2RelaxedMin),
@@ -1362,7 +1353,7 @@ fn append_instruction(ctx: &mut ValidationContext, inst: Operator, loc: InstrLoc
         Operator::I16x8RelaxedQ15mulrS => binop(ctx, BinaryOp::I16x8RelaxedQ15mulrS),
         Operator::I16x8RelaxedDotI8x16I7x16S => binop(ctx, BinaryOp::I16x8RelaxedDotI8x16I7x16S),
         Operator::I32x4RelaxedDotI8x16I7x16AddS => {
-            relaxed_simd(ctx, RelaxedSimdOp::I32x4RelaxedDotI8x16I7x16AddS)
+            ternop(ctx, TernaryOp::I32x4RelaxedDotI8x16I7x16AddS)
         }
 
         // List all unimplmented operators instead of have a catch-all arm.


### PR DESCRIPTION
This enabled the relaxed SIMD proposal, which is in phase 5, by default. `wasm-bindgen` currently fails without this addition when compiling Wasm modules containing relaxed SIMD instructions, which are stable since Rust v1.82.

A new point release would be appreciated as well!