### PR TITLE
Add missing ops to enable upgrade to 0.214

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ leb128 = "0.2.4"
 log = "0.4.8"
 rayon = { version = "1.1.0", optional = true }
 walrus-macro = { path = './crates/macro', version = '=0.22.0' }
-wasm-encoder = "0.213.0"
-wasmparser = "0.213.0"
+wasm-encoder = "0.214.0"
+wasmparser = "0.214.0"
 gimli = "0.26.0"
 
 [features]

--- a/src/module/functions/local_function/mod.rs
+++ b/src/module/functions/local_function/mod.rs
@@ -1465,6 +1465,122 @@ fn append_instruction(ctx: &mut ValidationContext, inst: Operator, loc: InstrLoc
             ordering: _,
             global_index: _,
         }
+        | Operator::TableAtomicGet {
+            ordering: _,
+            table_index: _,
+        }
+        | Operator::TableAtomicSet {
+            ordering: _,
+            table_index: _,
+        }
+        | Operator::TableAtomicRmwXchg {
+            ordering: _,
+            table_index: _,
+        }
+        | Operator::TableAtomicRmwCmpxchg {
+            ordering: _,
+            table_index: _,
+        }
+        | Operator::StructAtomicGet {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::StructAtomicGetS {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::StructAtomicGetU {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::StructAtomicSet {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::StructAtomicRmwAdd {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::StructAtomicRmwSub {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::StructAtomicRmwAnd {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::StructAtomicRmwOr {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::StructAtomicRmwXor {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::StructAtomicRmwXchg {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::StructAtomicRmwCmpxchg {
+            ordering: _,
+            struct_type_index: _,
+            field_index: _,
+        }
+        | Operator::ArrayAtomicGet {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::ArrayAtomicGetS {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::ArrayAtomicGetU {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::ArrayAtomicSet {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::ArrayAtomicRmwAdd {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::ArrayAtomicRmwSub {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::ArrayAtomicRmwAnd {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::ArrayAtomicRmwOr {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::ArrayAtomicRmwXor {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::ArrayAtomicRmwXchg {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::ArrayAtomicRmwCmpxchg {
+            ordering: _,
+            array_type_index: _,
+        }
+        | Operator::RefI31Shared
         | Operator::I8x16RelaxedSwizzle
         | Operator::I32x4RelaxedTruncF32x4S
         | Operator::I32x4RelaxedTruncF32x4U


### PR DESCRIPTION
Adds cases for the added shared-everything-threads instructions.

These instructions are part of the shared everything threads [proposal](https://github.com/bytecodealliance/wasm-tools/pull/1664) and were added to wasmparser in https://github.com/bytecodealliance/wasm-tools/commit/bf282bb1054a58b7989b112de522674999d4af50 

This change treats all of them as unsupported, with the intent to enable upgrading wasmparser and wasm-encoders tools dependencies in lock step.