### PR TITLE
Don't emit empty DWARF sections

### DIFF
--- a/src/module/debug/mod.rs
+++ b/src/module/debug/mod.rs
@@ -115,10 +115,12 @@ impl Emit for ModuleDebugData {
         sections
             .for_each(
                 |id: SectionId, data: &write::EndianVec<LittleEndian>| -> Result<()> {
-                    cx.wasm_module.section(&wasm_encoder::CustomSection {
-                        name: id.name().into(),
-                        data: data.slice().into(),
-                    });
+                    if !data.slice().is_empty() {
+                        cx.wasm_module.section(&wasm_encoder::CustomSection {
+                            name: id.name().into(),
+                            data: data.slice().into(),
+                        });
+                    }
                     Ok(())
                 },
             )


### PR DESCRIPTION
This change prevents empty custom sections for debug information to be generated when no debug information is available. `fallible-iterator` is not a new dependency, it is a dependency of `gimli`, but is not re-exported.

Not only are a bunch of empty custom sections undesirable, seemingly `wasm-opt` had issues parsing those. I'm unsure if this is a bug or not, I don't know if completely empty DWARF sections are valid or not.

This will enable `wasm-bindgen` to stop throwing away the debug information if its available.

See https://github.com/rustwasm/wasm-bindgen/pull/3876.