### PR TITLE
Add `Module::from_buffer_with_config`

### DIFF
--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -129,6 +129,11 @@ impl Module {
         ModuleConfig::new().parse(wasm)
     }
 
+    /// Construct a new module from the in-memory wasm buffer and configuration.
+    pub fn from_buffer_with_config(wasm: &[u8], config: &ModuleConfig) -> Result<Module> {
+        config.parse(wasm)
+    }
+
     fn parse(wasm: &[u8], config: &ModuleConfig) -> Result<Module> {
         let mut ret = Module {
             config: config.clone(),


### PR DESCRIPTION
Current `Module` construction API cannot create a module from a buffer with a specific configuration:
  * `Module::with_config`
  * `Module::from_file`
  * `Module::from_file_with_config`
  * `Module::from_buffer`

This commit adds a new method `Module::from_buffer_with_config` to fill the gap.

We are using this API to instrument wasm binary on browsers without relying on file system: https://github.com/kateinoigakukun/wasm-memprof