### PR TITLE
fix: data segment names

### DIFF
--- a/src/module/data.rs
+++ b/src/module/data.rs
@@ -177,7 +177,7 @@ impl Module {
     pub(crate) fn parse_data(
         &mut self,
         section: wasmparser::DataSectionReader,
-        ids: &IndicesToIds,
+        ids: &mut IndicesToIds,
     ) -> Result<()> {
         log::debug!("parse data section");
         let preallocated = self.data.arena.len() > 0;
@@ -189,12 +189,16 @@ impl Module {
             let id = if preallocated {
                 ids.get_data(i as u32)?
             } else {
-                self.data.arena.alloc_with_id(|id| Data {
+                let id = self.data.arena.alloc_with_id(|id| Data {
                     id,
                     value: Vec::new(),
                     kind: DataKind::Passive,
                     name: None,
-                })
+                });
+
+                ids.push_data(id);
+
+                id
             };
             let data = self.data.get_mut(id);
 

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -167,7 +167,7 @@ impl Module {
                     validator
                         .data_section(&s)
                         .context("failed to parse data section")?;
-                    ret.parse_data(s, &indices)?;
+                    ret.parse_data(s, &mut indices)?;
                 }
                 Payload::TypeSection(s) => {
                     validator


### PR DESCRIPTION
Data segment names are dropped with a warning if the input binary doesn't have a data count section:

```
[2024-12-11T18:37:45Z DEBUG walrus::module::types] parsing type section
[2024-12-11T18:37:45Z DEBUG walrus::module::imports] parse import section
[2024-12-11T18:37:45Z DEBUG walrus::module::functions] parse function section
[2024-12-11T18:37:45Z DEBUG walrus::module::tables] parse table section
[2024-12-11T18:37:45Z DEBUG walrus::module::memories] parse memory section
[2024-12-11T18:37:45Z DEBUG walrus::module::globals] parse global section
[2024-12-11T18:38:41Z INFO  wasm_bindgen] hi
[2024-12-11T18:38:43Z DEBUG walrus::module::types] parsing type section
[2024-12-11T18:38:43Z DEBUG walrus::module::imports] parse import section
[2024-12-11T18:38:43Z DEBUG walrus::module::functions] parse function section
[2024-12-11T18:38:43Z DEBUG walrus::module::tables] parse table section
[2024-12-11T18:38:43Z DEBUG walrus::module::memories] parse memory section
[2024-12-11T18:38:43Z DEBUG walrus::module::globals] parse global section
[2024-12-11T18:38:43Z DEBUG walrus::module::exports] parse export section
[2024-12-11T18:38:43Z DEBUG walrus::module::elements] parse element section
[2024-12-11T18:38:43Z DEBUG walrus::module::data] parse data section
[2024-12-11T18:38:43Z DEBUG walrus::module] parsing custom section `__wasm_bindgen_unstable`
[2024-12-11T18:38:43Z DEBUG walrus::module] parsing custom section `.debug_abbrev`
[2024-12-11T18:38:43Z DEBUG walrus::module] parsing custom section `.debug_info`
[2024-12-11T18:38:43Z DEBUG walrus::module] parsing custom section `.debug_ranges`
[2024-12-11T18:38:43Z DEBUG walrus::module] parsing custom section `.debug_str`
[2024-12-11T18:38:43Z DEBUG walrus::module] parsing custom section `.debug_pubnames`
[2024-12-11T18:38:43Z DEBUG walrus::module] parsing custom section `.debug_pubtypes`
[2024-12-11T18:38:43Z DEBUG walrus::module] parsing custom section `.debug_line`
[2024-12-11T18:38:45Z DEBUG walrus::module] parse name section
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `0` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `1` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `2` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `3` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `4` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `5` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `6` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `7` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `8` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `9` is out of bounds for data
...
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `1125` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `1126` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `1127` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `1128` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `1129` is out of bounds for data
[2024-12-11T18:38:45Z WARN  walrus::module] in name section: index `1130` is out of bounds for data
[2024-12-11T18:38:45Z DEBUG walrus::module::producers] parse producers section
[2024-12-11T18:38:45Z DEBUG walrus::module] parsing custom section `target_features`
[2024-12-11T18:38:45Z DEBUG walrus::module::functions] parse code section
[2024-12-11T18:38:46Z DEBUG walrus::module] parse complete
[2024-12-11T18:38:46Z DEBUG walrus::passes::used] starting to calculate used set
```

This is because the IDs are not updated as the data is being read.